### PR TITLE
Multi-checkpoint sweep: 14 models, multi-GPU, data augmentation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-torch>=1.6.0,<2
-transformers
+torch>=2.6.0
+transformers>=4.40.0
 datasets
 evaluate
 sentence-transformers
+sentencepiece
 poutyne
 scikit-learn
 numpy

--- a/src/training/cleanup.py
+++ b/src/training/cleanup.py
@@ -1,0 +1,150 @@
+"""Clean up failed wandb runs and intermediate training checkpoints.
+
+Usage::
+
+    # Dry run (show what would be deleted)
+    python cleanup.py
+
+    # Actually delete
+    python cleanup.py --delete
+
+    # Also clean failed/crashed wandb runs
+    python cleanup.py --delete --clean-wandb
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+from glob import glob
+from pathlib import Path
+
+
+TRAINING_DIR = Path(__file__).parent
+
+
+def find_intermediate_checkpoints() -> list[Path]:
+    """Find checkpoint-* directories inside training output dirs."""
+    results: list[Path] = []
+    for output_dir in sorted(TRAINING_DIR.glob("meaning_bert_train_*")):
+        if not output_dir.is_dir():
+            continue
+        for checkpoint_dir in sorted(output_dir.glob("checkpoint-*")):
+            if checkpoint_dir.is_dir():
+                results.append(checkpoint_dir)
+    return results
+
+
+def find_wandb_failed_runs() -> list[Path]:
+    """Find wandb run directories that crashed (no summary.json or short duration)."""
+    wandb_dir = TRAINING_DIR / "wandb"
+    if not wandb_dir.exists():
+        return []
+
+    results: list[Path] = []
+    for run_dir in sorted(wandb_dir.glob("run-*")):
+        if not run_dir.is_dir():
+            continue
+        # A run without a wandb-summary.json likely crashed
+        summary = run_dir / "files" / "wandb-summary.json"
+        if not summary.exists():
+            results.append(run_dir)
+    return results
+
+
+def get_dir_size(path: Path) -> int:
+    """Get total size of a directory in bytes."""
+    total = 0
+    for dirpath, _, filenames in os.walk(path):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            if os.path.isfile(fp):
+                total += os.path.getsize(fp)
+    return total
+
+
+def format_size(size_bytes: int) -> str:
+    """Format bytes as human-readable string."""
+    for unit in ["B", "KB", "MB", "GB"]:
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes /= 1024
+    return f"{size_bytes:.1f} TB"
+
+
+def clean_wandb_failed(delete: bool) -> None:
+    """Delete failed wandb runs via the API."""
+    try:
+        import wandb
+    except ImportError:
+        print("  wandb not installed, skipping API cleanup")
+        return
+
+    api = wandb.Api()
+    project = "davebulaval/meaningbert-checkpoint-sweep"
+    try:
+        runs = api.runs(project, filters={"state": "crashed"})
+    except Exception as e:
+        print(f"  Could not fetch wandb runs: {e}")
+        return
+
+    crashed = list(runs)
+    if not crashed:
+        print("  No crashed wandb runs found")
+        return
+
+    for run in crashed:
+        if delete:
+            run.delete()
+            print(f"  Deleted wandb run: {run.name} ({run.id})")
+        else:
+            print(f"  Would delete wandb run: {run.name} ({run.id})")
+    print(f"  Total: {len(crashed)} crashed runs")
+
+
+def main() -> None:
+    """Find and optionally delete intermediate checkpoints and failed runs."""
+    parser = argparse.ArgumentParser(description="Clean up training artifacts.")
+    parser.add_argument("--delete", action="store_true", help="Actually delete files (default: dry run).")
+    parser.add_argument("--clean-wandb", action="store_true", help="Also delete crashed wandb runs via API.")
+    args = parser.parse_args()
+
+    # 1. Intermediate checkpoints
+    print("=== Intermediate checkpoints ===")
+    checkpoints = find_intermediate_checkpoints()
+    total_size = 0
+    for cp in checkpoints:
+        size = get_dir_size(cp)
+        total_size += size
+        if args.delete:
+            shutil.rmtree(cp)
+            print(f"  Deleted: {cp} ({format_size(size)})")
+        else:
+            print(f"  Would delete: {cp} ({format_size(size)})")
+    print(f"  Total: {len(checkpoints)} checkpoints, {format_size(total_size)}")
+
+    # 2. Local wandb failed run directories
+    print("\n=== Failed local wandb runs ===")
+    failed_runs = find_wandb_failed_runs()
+    total_size = 0
+    for run_dir in failed_runs:
+        size = get_dir_size(run_dir)
+        total_size += size
+        if args.delete:
+            shutil.rmtree(run_dir)
+            print(f"  Deleted: {run_dir.name} ({format_size(size)})")
+        else:
+            print(f"  Would delete: {run_dir.name} ({format_size(size)})")
+    print(f"  Total: {len(failed_runs)} failed runs, {format_size(total_size)}")
+
+    # 3. Remote wandb crashed runs
+    if args.clean_wandb:
+        print("\n=== Crashed wandb runs (remote) ===")
+        clean_wandb_failed(args.delete)
+
+    if not args.delete:
+        print("\nDry run. Use --delete to actually remove files.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/training/ensemble_evaluate.py
+++ b/src/training/ensemble_evaluate.py
@@ -1,0 +1,121 @@
+"""Ensemble evaluation: average predictions from multiple trained models."""
+import argparse
+import glob
+import os
+
+import numpy as np
+import torch
+from datasets import load_dataset
+from scipy.stats import pearsonr
+from sklearn.metrics import r2_score
+from transformers import (
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    DataCollatorWithPadding,
+    Trainer,
+    TrainingArguments,
+)
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Ensemble evaluation over multiple saved models.")
+    parser.add_argument(
+        "--model_dirs",
+        type=str,
+        nargs="+",
+        required=True,
+        help="Paths to saved model directories (from trainer.save_model).",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="test",
+        choices=["test", "dev"],
+        help="Dataset split to evaluate on.",
+    )
+    return parser
+
+
+def get_predictions(model_dir: str, dataset, data_collator) -> np.ndarray:
+    """Load a model and return its predictions on the dataset."""
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    model = AutoModelForSequenceClassification.from_pretrained(model_dir, num_labels=1)
+    if model.config.pad_token_id is None:
+        model.config.pad_token_id = tokenizer.pad_token_id
+
+    training_args = TrainingArguments(
+        output_dir="/tmp/ensemble_eval",
+        per_device_eval_batch_size=64,
+        report_to="none",
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        data_collator=data_collator,
+        tokenizer=tokenizer,
+    )
+
+    predictions = trainer.predict(dataset)
+    return predictions.predictions.squeeze()
+
+
+def main():
+    parser = create_parser()
+    args = parser.parse_args()
+
+    # Load dataset
+    csmd_dataset = load_dataset("davebulaval/CSMD", "meaning")
+    holdout_identical = load_dataset("davebulaval/CSMD", "meaning_holdout_identical")
+    holdout_unrelated = load_dataset("davebulaval/CSMD", "meaning_holdout_unrelated")
+
+    # Use tokenizer from first model for tokenization
+    first_tokenizer = AutoTokenizer.from_pretrained(args.model_dirs[0])
+    if first_tokenizer.pad_token is None:
+        first_tokenizer.pad_token = first_tokenizer.eos_token
+
+    def tokenize_function(example):
+        return first_tokenizer(example["original"], example["simplification"], truncation=True, padding=True)
+
+    eval_dataset = csmd_dataset.map(tokenize_function, batched=True)
+    eval_identical = holdout_identical.map(tokenize_function, batched=True)
+    eval_unrelated = holdout_unrelated.map(tokenize_function, batched=True)
+    data_collator = DataCollatorWithPadding(first_tokenizer)
+
+    datasets_to_eval = {
+        "test": eval_dataset[args.split],
+        "holdout_identical": eval_identical["test"],
+        "holdout_unrelated": eval_unrelated["test"],
+    }
+
+    for dataset_name, dataset in datasets_to_eval.items():
+        all_preds = []
+        for model_dir in args.model_dirs:
+            print(f"Getting predictions from {model_dir} on {dataset_name}...")
+            preds = get_predictions(model_dir, dataset, data_collator)
+            all_preds.append(preds)
+
+        # Ensemble: simple average
+        ensemble_preds = np.mean(all_preds, axis=0)
+        labels = np.array(dataset["label"])
+
+        r2 = r2_score(labels, ensemble_preds)
+        pearson_r, pearson_p = pearsonr(labels, ensemble_preds)
+
+        print(f"\n=== Ensemble results on {dataset_name} ({len(args.model_dirs)} models) ===")
+        print(f"  R2:      {r2:.4f}")
+        print(f"  Pearson: {pearson_r:.4f} (p={pearson_p:.2e})")
+
+        # Per-model results for comparison
+        print(f"\n  Per-model R2:")
+        for model_dir, preds in zip(args.model_dirs, all_preds):
+            model_r2 = r2_score(labels, preds)
+            print(f"    {os.path.basename(model_dir)}: {model_r2:.4f}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/training/ensemble_evaluate.py
+++ b/src/training/ensemble_evaluate.py
@@ -1,11 +1,16 @@
-"""Ensemble evaluation: average predictions from multiple trained models."""
+"""Ensemble evaluation: average predictions from multiple trained models.
+
+Usage::
+
+    python ensemble_evaluate.py --model_dirs model_a/ model_b/ model_c/ --data_dir ./data --fold 0
+"""
+from __future__ import annotations
+
 import argparse
-import glob
 import os
 
 import numpy as np
-import torch
-from datasets import load_dataset
+from datasets import DatasetDict, load_dataset, load_from_disk
 from scipy.stats import pearsonr
 from sklearn.metrics import r2_score
 from transformers import (
@@ -16,28 +21,36 @@ from transformers import (
     TrainingArguments,
 )
 
+COLUMNS_TO_REMOVE: list[str] = ["source"]
 
-def create_parser():
+
+def create_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
     parser = argparse.ArgumentParser(description="Ensemble evaluation over multiple saved models.")
     parser.add_argument(
-        "--model_dirs",
-        type=str,
-        nargs="+",
-        required=True,
-        help="Paths to saved model directories (from trainer.save_model).",
+        "--model_dirs", type=str, nargs="+", required=True,
+        help="Paths to saved model directories.",
     )
+    parser.add_argument("--data_dir", type=str, default=None, help="Root data directory (from prepare_datasets.py).")
+    parser.add_argument("--fold", type=int, default=None, help="Fold index (0-9). Requires --data_dir.")
     parser.add_argument(
-        "--split",
-        type=str,
-        default="test",
-        choices=["test", "dev"],
+        "--split", type=str, default="test", choices=["test", "dev"],
         help="Dataset split to evaluate on.",
     )
     return parser
 
 
-def get_predictions(model_dir: str, dataset, data_collator) -> np.ndarray:
-    """Load a model and return its predictions on the dataset."""
+def get_predictions(model_dir: str, dataset: DatasetDict, data_collator: DataCollatorWithPadding) -> np.ndarray:
+    """Load a model and return its predictions on *dataset*.
+
+    Args:
+        model_dir: Path to a saved model directory.
+        dataset: Tokenized HF dataset split.
+        data_collator: Padding collator matching the tokenizer.
+
+    Returns:
+        1-D array of predicted scores.
+    """
     tokenizer = AutoTokenizer.from_pretrained(model_dir)
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
@@ -52,69 +65,57 @@ def get_predictions(model_dir: str, dataset, data_collator) -> np.ndarray:
         report_to="none",
     )
 
-    trainer = Trainer(
-        model=model,
-        args=training_args,
-        data_collator=data_collator,
-        tokenizer=tokenizer,
-    )
-
+    trainer = Trainer(model=model, args=training_args, data_collator=data_collator, tokenizer=tokenizer)
     predictions = trainer.predict(dataset)
     return predictions.predictions.squeeze()
 
 
-def main():
+def main() -> None:
+    """Load models, compute ensemble predictions, and print metrics."""
     parser = create_parser()
     args = parser.parse_args()
 
     # Load dataset
-    csmd_dataset = load_dataset("davebulaval/CSMD", "meaning")
-    holdout_identical = load_dataset("davebulaval/CSMD", "meaning_holdout_identical")
-    holdout_unrelated = load_dataset("davebulaval/CSMD", "meaning_holdout_unrelated")
+    if args.data_dir is not None and args.fold is not None:
+        fold_dir = os.path.join(args.data_dir, "folds", f"fold_{args.fold}", "meaning")
+        csmd_dataset = load_from_disk(fold_dir)
+    else:
+        csmd_dataset = load_dataset("davebulaval/CSMD", "meaning")
 
-    # Use tokenizer from first model for tokenization
+    # Use tokenizer from first model
     first_tokenizer = AutoTokenizer.from_pretrained(args.model_dirs[0])
     if first_tokenizer.pad_token is None:
         first_tokenizer.pad_token = first_tokenizer.eos_token
 
-    def tokenize_function(example):
+    def tokenize_function(example: dict) -> dict:
         return first_tokenizer(example["original"], example["simplification"], truncation=True, padding=True)
 
-    eval_dataset = csmd_dataset.map(tokenize_function, batched=True)
-    eval_identical = holdout_identical.map(tokenize_function, batched=True)
-    eval_unrelated = holdout_unrelated.map(tokenize_function, batched=True)
+    cols = [c for c in COLUMNS_TO_REMOVE if c in csmd_dataset[args.split].column_names]
+    eval_dataset = csmd_dataset.map(tokenize_function, batched=True, remove_columns=cols)
     data_collator = DataCollatorWithPadding(first_tokenizer)
 
-    datasets_to_eval = {
-        "test": eval_dataset[args.split],
-        "holdout_identical": eval_identical["test"],
-        "holdout_unrelated": eval_unrelated["test"],
-    }
+    dataset = eval_dataset[args.split]
+    all_preds: list[np.ndarray] = []
+    for model_dir in args.model_dirs:
+        print(f"Getting predictions from {model_dir}...")
+        preds = get_predictions(model_dir, dataset, data_collator)
+        all_preds.append(preds)
 
-    for dataset_name, dataset in datasets_to_eval.items():
-        all_preds = []
-        for model_dir in args.model_dirs:
-            print(f"Getting predictions from {model_dir} on {dataset_name}...")
-            preds = get_predictions(model_dir, dataset, data_collator)
-            all_preds.append(preds)
+    # Ensemble: simple average
+    ensemble_preds = np.mean(all_preds, axis=0)
+    labels = np.array(dataset["label"])
 
-        # Ensemble: simple average
-        ensemble_preds = np.mean(all_preds, axis=0)
-        labels = np.array(dataset["label"])
+    r2 = r2_score(labels, ensemble_preds)
+    pearson_r, pearson_p = pearsonr(labels, ensemble_preds)
 
-        r2 = r2_score(labels, ensemble_preds)
-        pearson_r, pearson_p = pearsonr(labels, ensemble_preds)
+    print(f"\n=== Ensemble results ({len(args.model_dirs)} models) ===")
+    print(f"  R2:      {r2:.4f}")
+    print(f"  Pearson: {pearson_r:.4f} (p={pearson_p:.2e})")
 
-        print(f"\n=== Ensemble results on {dataset_name} ({len(args.model_dirs)} models) ===")
-        print(f"  R2:      {r2:.4f}")
-        print(f"  Pearson: {pearson_r:.4f} (p={pearson_p:.2e})")
-
-        # Per-model results for comparison
-        print(f"\n  Per-model R2:")
-        for model_dir, preds in zip(args.model_dirs, all_preds):
-            model_r2 = r2_score(labels, preds)
-            print(f"    {os.path.basename(model_dir)}: {model_r2:.4f}")
-        print()
+    print(f"\n  Per-model R2:")
+    for model_dir, preds in zip(args.model_dirs, all_preds):
+        model_r2 = r2_score(labels, preds)
+        print(f"    {os.path.basename(model_dir)}: {model_r2:.4f}")
 
 
 if __name__ == "__main__":

--- a/src/training/ensemble_evaluate.py
+++ b/src/training/ensemble_evaluate.py
@@ -10,7 +10,7 @@ import argparse
 import os
 
 import numpy as np
-from datasets import DatasetDict, load_dataset, load_from_disk
+from datasets import Dataset, load_dataset, load_from_disk
 from scipy.stats import pearsonr
 from sklearn.metrics import r2_score
 from transformers import (
@@ -40,7 +40,7 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def get_predictions(model_dir: str, dataset: DatasetDict, data_collator: DataCollatorWithPadding) -> np.ndarray:
+def get_predictions(model_dir: str, dataset: Dataset, data_collator: DataCollatorWithPadding) -> np.ndarray:
     """Load a model and return its predictions on *dataset*.
 
     Args:

--- a/src/training/ensemble_evaluate.py
+++ b/src/training/ensemble_evaluate.py
@@ -65,7 +65,7 @@ def get_predictions(model_dir: str, dataset: Dataset, data_collator: DataCollato
         report_to="none",
     )
 
-    trainer = Trainer(model=model, args=training_args, data_collator=data_collator, tokenizer=tokenizer)
+    trainer = Trainer(model=model, args=training_args, data_collator=data_collator, processing_class=tokenizer)
     predictions = trainer.predict(dataset)
     return predictions.predictions.squeeze()
 

--- a/src/training/few_shot_training.py
+++ b/src/training/few_shot_training.py
@@ -229,7 +229,7 @@ def main() -> None:
         run_name=run_name,
         report_to="wandb",
         logging_strategy="epoch",
-        evaluation_strategy="epoch",
+        eval_strategy="epoch",
         per_device_train_batch_size=batch_size,
         per_device_eval_batch_size=batch_size * 2,
         gradient_accumulation_steps=grad_accum,

--- a/src/training/few_shot_training.py
+++ b/src/training/few_shot_training.py
@@ -265,7 +265,7 @@ def main() -> None:
         train_dataset=tokenized_csmd_dataset["train"],
         eval_dataset=tokenized_csmd_dataset["dev"],
         data_collator=data_collator,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,
         compute_metrics=compute_metrics,
         callbacks=callbacks,
     )

--- a/src/training/few_shot_training.py
+++ b/src/training/few_shot_training.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import shutil
 from typing import Optional
 
 import wandb
@@ -336,6 +337,12 @@ def main() -> None:
     artifact.add_dir(best_model_dir)
     wandb.log_artifact(artifact)
     print(f"Model artifact logged to wandb: {artifact_name}")
+
+    # Clean up intermediate checkpoints to save disk space
+    output_dir = f"meaning_bert_train_{checkpoint_short_name}"
+    if os.path.isdir(output_dir):
+        shutil.rmtree(output_dir)
+        print(f"Cleaned up intermediate checkpoints: {output_dir}")
 
 
 if __name__ == "__main__":

--- a/src/training/few_shot_training.py
+++ b/src/training/few_shot_training.py
@@ -1,17 +1,22 @@
+"""Fine-tune a pretrained model for meaning preservation regression on CSMD."""
+from __future__ import annotations
+
 import argparse
 import logging
 import os
+from typing import Optional
 
 import wandb
 from datasets import DatasetDict, load_dataset, load_from_disk
 from poutyne import set_seeds
 from transformers import (
     AutoModelForSequenceClassification,
-    TrainingArguments,
     AutoTokenizer,
     DataCollatorWithPadding,
-    Trainer,
     EarlyStoppingCallback,
+    PreTrainedModel,
+    Trainer,
+    TrainingArguments,
 )
 
 from metrics.metrics import compute_metrics, eval_compute_metrics_identical, eval_compute_metrics_unrelated
@@ -20,11 +25,11 @@ log = logging.getLogger("pytorch_lightning")
 log.propagate = False
 log.setLevel(logging.ERROR)
 
-num_epoch = 500
+NUM_EPOCH = 500
 
 # Default learning rates per model family.
 # Decoder-based and DeBERTa models tend to need lower LRs than BERT.
-MODEL_FAMILY_LR = {
+MODEL_FAMILY_LR: dict[str, float] = {
     "deberta": 2e-5,
     "electra": 3e-5,
     "modernbert": 5e-5,
@@ -34,11 +39,24 @@ MODEL_FAMILY_LR = {
     "gemma": 1e-5,
     "phi": 1e-5,
 }
-DEFAULT_LR = 5e-5
+DEFAULT_LR: float = 5e-5
+
+AUGMENTATION_DIR_MAP: dict[str, str] = {
+    "none": "meaning",
+    "swap": "meaning_with_swap",
+    "back_translation": "meaning_with_back_translation",
+}
+AUGMENTATION_HF_MAP: dict[str, str] = {
+    "none": "meaning",
+    "swap": "meaning_with_data_augmentation",
+}
+
+# Columns added during data augmentation that are not model inputs.
+COLUMNS_TO_REMOVE: list[str] = ["source"]
 
 
 def get_default_lr(checkpoint: str) -> float:
-    """Return a sensible default LR based on the checkpoint name."""
+    """Return a sensible default learning rate based on the checkpoint name."""
     checkpoint_lower = checkpoint.lower()
     for family, lr in MODEL_FAMILY_LR.items():
         if family in checkpoint_lower:
@@ -46,8 +64,11 @@ def get_default_lr(checkpoint: str) -> float:
     return DEFAULT_LR
 
 
-def freeze_layers(model, num_layers_to_freeze: int) -> None:
-    """Freeze the first `num_layers_to_freeze` transformer layers of the model."""
+def freeze_layers(model: PreTrainedModel, num_layers_to_freeze: int) -> None:
+    """Freeze the first *num_layers_to_freeze* transformer layers of *model*.
+
+    Supports BERT, DeBERTa v2/v3, ELECTRA, GPT-2, LLaMA-family, and ModernBERT.
+    """
     if num_layers_to_freeze <= 0:
         return
 
@@ -73,7 +94,7 @@ def freeze_layers(model, num_layers_to_freeze: int) -> None:
             break
 
     if layer_list is None:
-        print(f"WARNING: Could not find layer list for freezing. Skipping layer freeze.")
+        print("WARNING: Could not find layer list for freezing. Skipping layer freeze.")
         return
 
     n = min(num_layers_to_freeze, len(layer_list))
@@ -83,151 +104,95 @@ def freeze_layers(model, num_layers_to_freeze: int) -> None:
     print(f"Froze {n}/{len(layer_list)} layers.")
 
 
-def create_parser():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--seed",
-        type=int,
-        default=45,
-        help="The seed to use for training.",
-    )
+def create_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+    parser = argparse.ArgumentParser(description="Fine-tune a model for meaning preservation regression.")
 
+    parser.add_argument("--seed", type=int, default=45, help="Random seed for training.")
     parser.add_argument(
-        "--root",
-        type=str,
-        default=".",
-        help="Root directory.",
+        "--data_dir", type=str, default=None,
+        help="Root directory containing pre-generated datasets (from prepare_datasets.py).",
     )
-
     parser.add_argument(
-        "--data_dir",
-        type=str,
-        default=None,
-        help="Root directory containing pre-generated datasets (from prepare_datasets.py). "
-             "When set, loads from disk instead of HuggingFace Hub.",
+        "--fold", type=int, default=None,
+        help="Fold index for k-fold cross-validation (0-9). Requires --data_dir.",
     )
-
     parser.add_argument(
-        "--fold",
-        type=int,
-        default=None,
-        help="Fold index for k-fold cross-validation (0-9). "
-             "Requires --data_dir. Loads from data_dir/folds/fold_N/.",
-    )
-
-    parser.add_argument(
-        "--data_augmentation",
-        type=str,
-        default="swap",
+        "--data_augmentation", type=str, default="swap",
         choices=["none", "swap", "back_translation"],
-        help="Data augmentation variant: 'none' (base), 'swap' (commutative), "
-             "'back_translation' (swap + back-translation).",
+        help="Data augmentation variant.",
     )
-
     parser.add_argument(
-        "--checkpoint",
-        type=str,
-        default="bert-base-uncased",
-        help="The pretrained model checkpoint to use for fine-tuning.",
+        "--checkpoint", type=str, default="bert-base-uncased",
+        help="Pretrained model checkpoint for fine-tuning.",
     )
-
     parser.add_argument(
-        "--learning_rate",
-        type=float,
-        default=None,
+        "--learning_rate", type=float, default=None,
         help="Learning rate. If not set, uses a per-model-family default.",
     )
-
+    parser.add_argument("--freeze_layers", type=int, default=0, help="Number of bottom layers to freeze.")
+    parser.add_argument("--per_device_train_batch_size", type=int, default=64, help="Training batch size per device.")
     parser.add_argument(
-        "--freeze_layers",
-        type=int,
-        default=0,
-        help="Number of bottom transformer layers to freeze.",
-    )
-
-    parser.add_argument(
-        "--per_device_train_batch_size",
-        type=int,
-        default=16,
-        help="Training batch size per device.",
-    )
-
-    parser.add_argument(
-        "--gradient_accumulation_steps",
-        type=int,
-        default=1,
+        "--gradient_accumulation_steps", type=int, default=1,
         help="Gradient accumulation steps (effective batch = batch_size * accumulation).",
     )
-
     parser.add_argument(
-        "--early_stopping_patience",
-        type=int,
-        default=50,
+        "--bf16", action="store_true", default=True,
+        help="Use bfloat16 mixed precision (recommended for RTX Ada GPUs).",
+    )
+    parser.add_argument("--dataloader_num_workers", type=int, default=4, help="Number of dataloader workers.")
+    parser.add_argument(
+        "--early_stopping_patience", type=int, default=50,
         help="Early stopping patience in epochs. 0 to disable.",
     )
     return parser
 
 
-def main():
+def main() -> None:
+    """Entry point: parse args, load data, train, evaluate, and log artifacts."""
     parser = create_parser()
     args = parser.parse_args()
 
-    seed = args.seed
-    root = args.root
-    data_dir = args.data_dir
-    fold = args.fold
-    data_augmentation = args.data_augmentation
-    checkpoint = args.checkpoint
-    lr = args.learning_rate if args.learning_rate is not None else get_default_lr(checkpoint)
-    num_freeze = args.freeze_layers
-    batch_size = args.per_device_train_batch_size
-    grad_accum = args.gradient_accumulation_steps
-    es_patience = args.early_stopping_patience
+    seed: int = args.seed
+    data_dir: Optional[str] = args.data_dir
+    fold: Optional[int] = args.fold
+    data_augmentation: str = args.data_augmentation
+    checkpoint: str = args.checkpoint
+    lr: float = args.learning_rate if args.learning_rate is not None else get_default_lr(checkpoint)
+    num_freeze: int = args.freeze_layers
+    batch_size: int = args.per_device_train_batch_size
+    grad_accum: int = args.gradient_accumulation_steps
+    use_bf16: bool = args.bf16
+    num_workers: int = args.dataloader_num_workers
+    es_patience: int = args.early_stopping_patience
 
     set_seeds(seed=seed)
 
-    # Map augmentation variant to directory names
-    AUGMENTATION_DIR_MAP = {
-        "none": "meaning",
-        "swap": "meaning_with_swap",
-        "back_translation": "meaning_with_back_translation",
-    }
-    AUGMENTATION_HF_MAP = {
-        "none": "meaning",
-        "swap": "meaning_with_data_augmentation",
-    }
+    # --- Load datasets ---
+    holdout_identical_dataset: Optional[DatasetDict] = None
+    holdout_unrelated_dataset: Optional[DatasetDict] = None
 
     if data_dir is not None:
-        # Build path: data_dir/folds/fold_N/<augmentation> or data_dir/<augmentation>
-        if fold is not None:
-            base_path = os.path.join(data_dir, "folds", f"fold_{fold}")
-        else:
-            base_path = data_dir
+        base_path = os.path.join(data_dir, "folds", f"fold_{fold}") if fold is not None else data_dir
         dataset_path = os.path.join(base_path, AUGMENTATION_DIR_MAP[data_augmentation])
         print(f"Loading dataset from disk: {dataset_path}")
         csmd_dataset = load_from_disk(dataset_path)
 
         if fold is not None:
-            # With k-fold: identical and unrelated are in the fold splits (stratified).
+            # With k-fold: identical/unrelated are in the fold splits (stratified).
             # Extract them from the test set by source tag for holdout evaluation.
             test_set = csmd_dataset["test"]
             if "source" in test_set.column_names:
-                identical_mask = [s == "identical" for s in test_set["source"]]
-                unrelated_mask = [s == "unrelated" for s in test_set["source"]]
                 holdout_identical_dataset = DatasetDict({
-                    "test": test_set.select([i for i, m in enumerate(identical_mask) if m])
+                    "test": test_set.filter(lambda x: x["source"] == "identical")
                 })
                 holdout_unrelated_dataset = DatasetDict({
-                    "test": test_set.select([i for i, m in enumerate(unrelated_mask) if m])
+                    "test": test_set.filter(lambda x: x["source"] == "unrelated")
                 })
-            else:
-                holdout_identical_dataset = None
-                holdout_unrelated_dataset = None
         else:
             holdout_identical_dataset = load_from_disk(os.path.join(data_dir, "meaning_holdout_identical"))
             holdout_unrelated_dataset = load_from_disk(os.path.join(data_dir, "meaning_holdout_unrelated"))
     else:
-        # Fallback: download from HuggingFace Hub (no back_translation available)
         if data_augmentation == "back_translation":
             raise ValueError("--data_dir is required for back_translation. Run prepare_datasets.py first.")
         hf_config = AUGMENTATION_HF_MAP[data_augmentation]
@@ -236,19 +201,24 @@ def main():
         holdout_identical_dataset = load_dataset("davebulaval/CSMD", "meaning_holdout_identical")
         holdout_unrelated_dataset = load_dataset("davebulaval/CSMD", "meaning_holdout_unrelated")
 
+    # --- Tokenization ---
     tokenizer = AutoTokenizer.from_pretrained(checkpoint)
 
     # Decoder-based models (GPT-2, LLaMA, etc.) don't have a pad token by default.
-    # Use eos_token as pad_token for proper batching and padding.
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
 
-    def tokenize_function(example):
+    def tokenize_function(example: dict) -> dict:
         return tokenizer(example["original"], example["simplification"], truncation=True, padding=True)
 
-    tokenized_csmd_dataset = csmd_dataset.map(tokenize_function, batched=True)
+    # Remove non-tensor columns before tokenization to avoid Trainer collation errors.
+    cols_to_remove = [c for c in COLUMNS_TO_REMOVE if c in csmd_dataset["train"].column_names]
+    tokenized_csmd_dataset = csmd_dataset.map(
+        tokenize_function, batched=True, remove_columns=cols_to_remove, num_proc=4,
+    )
     data_collator = DataCollatorWithPadding(tokenizer=tokenizer)
 
+    # --- Training config ---
     checkpoint_short_name = checkpoint.replace("/", "_")
     effective_batch = batch_size * grad_accum
     fold_str = f"_fold{fold}" if fold is not None else ""
@@ -261,26 +231,27 @@ def main():
         logging_strategy="epoch",
         evaluation_strategy="epoch",
         per_device_train_batch_size=batch_size,
-        per_device_eval_batch_size=64,
+        per_device_eval_batch_size=batch_size * 2,
         gradient_accumulation_steps=grad_accum,
-        num_train_epochs=num_epoch,
+        num_train_epochs=NUM_EPOCH,
         save_total_limit=3,
         save_strategy="epoch",
         load_best_model_at_end=True,
         seed=seed,
         metric_for_best_model="eval_loss",
         learning_rate=lr,
+        bf16=use_bf16,
+        dataloader_num_workers=num_workers,
+        dataloader_pin_memory=True,
     )
 
-    # num_labels to 1 to create a regression head
-    # REF: https://discuss.huggingface.co/t/fine-tune-bert-and-camembert-for-regression-problem/332/17
+    # Regression head: num_labels=1
     model = AutoModelForSequenceClassification.from_pretrained(checkpoint, num_labels=1)
 
     # Sync model pad_token_id with tokenizer (needed for decoder-based models).
     if model.config.pad_token_id is None:
         model.config.pad_token_id = tokenizer.pad_token_id
 
-    # Layer freezing
     if num_freeze > 0:
         freeze_layers(model, num_freeze)
 
@@ -298,6 +269,8 @@ def main():
         compute_metrics=compute_metrics,
         callbacks=callbacks,
     )
+
+    # --- Train ---
     print("----------Training start----------")
     trainer.train()
 
@@ -311,42 +284,43 @@ def main():
     })
     wandb.log({"Best model checkpoint path": trainer.state.best_model_checkpoint})
 
+    # --- Evaluate ---
     print("----------Test Set Evaluation start----------")
     test_results = trainer.evaluate(eval_dataset=tokenized_csmd_dataset["test"], metric_key_prefix="test")
 
-    # Evaluate holdout splits (identical / unrelated sentences)
-    identical_results = {}
-    unrelated_results = {}
+    identical_results: dict = {}
+    unrelated_results: dict = {}
 
     if holdout_identical_dataset is not None and len(holdout_identical_dataset["test"]) > 0:
-        tokenize_holdout_identical_dataset = holdout_identical_dataset.map(tokenize_function, batched=True)
+        cols = [c for c in COLUMNS_TO_REMOVE if c in holdout_identical_dataset["test"].column_names]
+        tok_identical = holdout_identical_dataset.map(tokenize_function, batched=True, remove_columns=cols)
         trainer.compute_metrics = eval_compute_metrics_identical
         identical_results = trainer.evaluate(
-            eval_dataset=tokenize_holdout_identical_dataset["test"],
-            metric_key_prefix="test/identical_sentences",
+            eval_dataset=tok_identical["test"], metric_key_prefix="test/identical_sentences",
         )
 
     if holdout_unrelated_dataset is not None and len(holdout_unrelated_dataset["test"]) > 0:
-        tokenize_holdout_unrelated_dataset = holdout_unrelated_dataset.map(tokenize_function, batched=True)
+        cols = [c for c in COLUMNS_TO_REMOVE if c in holdout_unrelated_dataset["test"].column_names]
+        tok_unrelated = holdout_unrelated_dataset.map(tokenize_function, batched=True, remove_columns=cols)
         trainer.compute_metrics = eval_compute_metrics_unrelated
         unrelated_results = trainer.evaluate(
-            eval_dataset=tokenize_holdout_unrelated_dataset["test"],
-            metric_key_prefix="test/unrelated_sentences",
+            eval_dataset=tok_unrelated["test"], metric_key_prefix="test/unrelated_sentences",
         )
 
-    # Save best model locally
-    best_model_dir = f"meaningbert_best_model_{checkpoint_short_name}_{seed}"
+    # --- Save & log artifact ---
+    best_model_dir = f"meaningbert_best_model_{checkpoint_short_name}_seed{seed}{fold_str}"
     trainer.save_model(best_model_dir)
     tokenizer.save_pretrained(best_model_dir)
 
-    # Log best model as wandb artifact for later ensemble/deployment
+    artifact_name = f"meaningbert-{checkpoint_short_name}-seed{seed}{fold_str}"
     artifact = wandb.Artifact(
-        name=f"meaningbert-{checkpoint_short_name}-seed{seed}",
+        name=artifact_name,
         type="model",
         description=f"Best MeaningBERT model fine-tuned from {checkpoint}",
         metadata={
             "checkpoint": checkpoint,
             "seed": seed,
+            "fold": fold,
             "learning_rate": lr,
             "freeze_layers": num_freeze,
             "effective_batch_size": effective_batch,
@@ -361,7 +335,7 @@ def main():
     )
     artifact.add_dir(best_model_dir)
     wandb.log_artifact(artifact)
-    print(f"Model artifact logged to wandb: meaningbert-{checkpoint_short_name}-seed{seed}")
+    print(f"Model artifact logged to wandb: {artifact_name}")
 
 
 if __name__ == "__main__":

--- a/src/training/few_shot_training.py
+++ b/src/training/few_shot_training.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 import wandb
-from datasets import load_dataset, load_from_disk
+from datasets import DatasetDict, load_dataset, load_from_disk
 from poutyne import set_seeds
 from transformers import (
     AutoModelForSequenceClassification,
@@ -108,6 +108,14 @@ def create_parser():
     )
 
     parser.add_argument(
+        "--fold",
+        type=int,
+        default=None,
+        help="Fold index for k-fold cross-validation (0-9). "
+             "Requires --data_dir. Loads from data_dir/folds/fold_N/.",
+    )
+
+    parser.add_argument(
         "--data_augmentation",
         type=str,
         default="swap",
@@ -167,6 +175,7 @@ def main():
     seed = args.seed
     root = args.root
     data_dir = args.data_dir
+    fold = args.fold
     data_augmentation = args.data_augmentation
     checkpoint = args.checkpoint
     lr = args.learning_rate if args.learning_rate is not None else get_default_lr(checkpoint)
@@ -177,7 +186,7 @@ def main():
 
     set_seeds(seed=seed)
 
-    # Map augmentation variant to directory/HF config names
+    # Map augmentation variant to directory names
     AUGMENTATION_DIR_MAP = {
         "none": "meaning",
         "swap": "meaning_with_swap",
@@ -189,12 +198,34 @@ def main():
     }
 
     if data_dir is not None:
-        # Load from pre-generated local datasets
-        dataset_path = os.path.join(data_dir, AUGMENTATION_DIR_MAP[data_augmentation])
+        # Build path: data_dir/folds/fold_N/<augmentation> or data_dir/<augmentation>
+        if fold is not None:
+            base_path = os.path.join(data_dir, "folds", f"fold_{fold}")
+        else:
+            base_path = data_dir
+        dataset_path = os.path.join(base_path, AUGMENTATION_DIR_MAP[data_augmentation])
         print(f"Loading dataset from disk: {dataset_path}")
         csmd_dataset = load_from_disk(dataset_path)
-        holdout_identical_dataset = load_from_disk(os.path.join(data_dir, "meaning_holdout_identical"))
-        holdout_unrelated_dataset = load_from_disk(os.path.join(data_dir, "meaning_holdout_unrelated"))
+
+        if fold is not None:
+            # With k-fold: identical and unrelated are in the fold splits (stratified).
+            # Extract them from the test set by source tag for holdout evaluation.
+            test_set = csmd_dataset["test"]
+            if "source" in test_set.column_names:
+                identical_mask = [s == "identical" for s in test_set["source"]]
+                unrelated_mask = [s == "unrelated" for s in test_set["source"]]
+                holdout_identical_dataset = DatasetDict({
+                    "test": test_set.select([i for i, m in enumerate(identical_mask) if m])
+                })
+                holdout_unrelated_dataset = DatasetDict({
+                    "test": test_set.select([i for i, m in enumerate(unrelated_mask) if m])
+                })
+            else:
+                holdout_identical_dataset = None
+                holdout_unrelated_dataset = None
+        else:
+            holdout_identical_dataset = load_from_disk(os.path.join(data_dir, "meaning_holdout_identical"))
+            holdout_unrelated_dataset = load_from_disk(os.path.join(data_dir, "meaning_holdout_unrelated"))
     else:
         # Fallback: download from HuggingFace Hub (no back_translation available)
         if data_augmentation == "back_translation":
@@ -216,13 +247,12 @@ def main():
         return tokenizer(example["original"], example["simplification"], truncation=True, padding=True)
 
     tokenized_csmd_dataset = csmd_dataset.map(tokenize_function, batched=True)
-    tokenize_holdout_identical_dataset = holdout_identical_dataset.map(tokenize_function, batched=True)
-    tokenize_holdout_unrelated_dataset = holdout_unrelated_dataset.map(tokenize_function, batched=True)
     data_collator = DataCollatorWithPadding(tokenizer=tokenizer)
 
     checkpoint_short_name = checkpoint.replace("/", "_")
     effective_batch = batch_size * grad_accum
-    run_name = f"{checkpoint_short_name}_seed{seed}_lr{lr}_bs{effective_batch}_freeze{num_freeze}_aug{data_augmentation}"
+    fold_str = f"_fold{fold}" if fold is not None else ""
+    run_name = f"{checkpoint_short_name}_seed{seed}_lr{lr}_bs{effective_batch}_freeze{num_freeze}_aug{data_augmentation}{fold_str}"
 
     training_args = TrainingArguments(
         output_dir=f"meaning_bert_train_{checkpoint_short_name}",
@@ -273,6 +303,7 @@ def main():
 
     wandb.run.config.update({
         "data_augmentation": data_augmentation,
+        "fold": fold,
         "checkpoint": checkpoint,
         "freeze_layers": num_freeze,
         "effective_batch_size": effective_batch,
@@ -283,18 +314,25 @@ def main():
     print("----------Test Set Evaluation start----------")
     test_results = trainer.evaluate(eval_dataset=tokenized_csmd_dataset["test"], metric_key_prefix="test")
 
-    # We change the computed metrics for the holdout splits
-    trainer.compute_metrics = eval_compute_metrics_identical
-    identical_results = trainer.evaluate(
-        eval_dataset=tokenize_holdout_identical_dataset["test"],
-        metric_key_prefix="test/identical_sentences",
-    )
+    # Evaluate holdout splits (identical / unrelated sentences)
+    identical_results = {}
+    unrelated_results = {}
 
-    trainer.compute_metrics = eval_compute_metrics_unrelated
-    unrelated_results = trainer.evaluate(
-        eval_dataset=tokenize_holdout_unrelated_dataset["test"],
-        metric_key_prefix="test/unrelated_sentences",
-    )
+    if holdout_identical_dataset is not None and len(holdout_identical_dataset["test"]) > 0:
+        tokenize_holdout_identical_dataset = holdout_identical_dataset.map(tokenize_function, batched=True)
+        trainer.compute_metrics = eval_compute_metrics_identical
+        identical_results = trainer.evaluate(
+            eval_dataset=tokenize_holdout_identical_dataset["test"],
+            metric_key_prefix="test/identical_sentences",
+        )
+
+    if holdout_unrelated_dataset is not None and len(holdout_unrelated_dataset["test"]) > 0:
+        tokenize_holdout_unrelated_dataset = holdout_unrelated_dataset.map(tokenize_function, batched=True)
+        trainer.compute_metrics = eval_compute_metrics_unrelated
+        unrelated_results = trainer.evaluate(
+            eval_dataset=tokenize_holdout_unrelated_dataset["test"],
+            metric_key_prefix="test/unrelated_sentences",
+        )
 
     # Save best model locally
     best_model_dir = f"meaningbert_best_model_{checkpoint_short_name}_{seed}"

--- a/src/training/few_shot_training.py
+++ b/src/training/few_shot_training.py
@@ -1,8 +1,9 @@
 import argparse
 import logging
+import os
 
 import wandb
-from datasets import load_dataset
+from datasets import load_dataset, load_from_disk
 from poutyne import set_seeds
 from transformers import (
     AutoModelForSequenceClassification,
@@ -10,18 +11,76 @@ from transformers import (
     AutoTokenizer,
     DataCollatorWithPadding,
     Trainer,
+    EarlyStoppingCallback,
 )
 
 from metrics.metrics import compute_metrics, eval_compute_metrics_identical, eval_compute_metrics_unrelated
-from tools import (
-    bool_parse,
-)
 
 log = logging.getLogger("pytorch_lightning")
 log.propagate = False
 log.setLevel(logging.ERROR)
 
 num_epoch = 500
+
+# Default learning rates per model family.
+# Decoder-based and DeBERTa models tend to need lower LRs than BERT.
+MODEL_FAMILY_LR = {
+    "deberta": 2e-5,
+    "electra": 3e-5,
+    "modernbert": 5e-5,
+    "gpt2": 2e-5,
+    "smollm": 2e-5,
+    "qwen": 1e-5,
+    "gemma": 1e-5,
+    "phi": 1e-5,
+}
+DEFAULT_LR = 5e-5
+
+
+def get_default_lr(checkpoint: str) -> float:
+    """Return a sensible default LR based on the checkpoint name."""
+    checkpoint_lower = checkpoint.lower()
+    for family, lr in MODEL_FAMILY_LR.items():
+        if family in checkpoint_lower:
+            return lr
+    return DEFAULT_LR
+
+
+def freeze_layers(model, num_layers_to_freeze: int) -> None:
+    """Freeze the first `num_layers_to_freeze` transformer layers of the model."""
+    if num_layers_to_freeze <= 0:
+        return
+
+    # Locate the layer list depending on the model architecture.
+    layer_list = None
+    for attr_path in [
+        "base_model.encoder.layer",       # BERT, DeBERTa, ELECTRA
+        "deberta.encoder.layer",           # DeBERTa v2/v3
+        "model.layers",                    # LLaMA, Qwen, Gemma, Phi, SmolLM
+        "transformer.h",                   # GPT-2
+        "encoder.layers",                  # ModernBERT
+    ]:
+        obj = model
+        found = True
+        for part in attr_path.split("."):
+            if hasattr(obj, part):
+                obj = getattr(obj, part)
+            else:
+                found = False
+                break
+        if found and hasattr(obj, "__len__"):
+            layer_list = obj
+            break
+
+    if layer_list is None:
+        print(f"WARNING: Could not find layer list for freezing. Skipping layer freeze.")
+        return
+
+    n = min(num_layers_to_freeze, len(layer_list))
+    for layer in layer_list[:n]:
+        for param in layer.parameters():
+            param.requires_grad = False
+    print(f"Froze {n}/{len(layer_list)} layers.")
 
 
 def create_parser():
@@ -41,10 +100,62 @@ def create_parser():
     )
 
     parser.add_argument(
+        "--data_dir",
+        type=str,
+        default=None,
+        help="Root directory containing pre-generated datasets (from prepare_datasets.py). "
+             "When set, loads from disk instead of HuggingFace Hub.",
+    )
+
+    parser.add_argument(
         "--data_augmentation",
-        type=bool_parse,
-        default=True,
-        help="Either or not to do data augmentation.",
+        type=str,
+        default="swap",
+        choices=["none", "swap", "back_translation"],
+        help="Data augmentation variant: 'none' (base), 'swap' (commutative), "
+             "'back_translation' (swap + back-translation).",
+    )
+
+    parser.add_argument(
+        "--checkpoint",
+        type=str,
+        default="bert-base-uncased",
+        help="The pretrained model checkpoint to use for fine-tuning.",
+    )
+
+    parser.add_argument(
+        "--learning_rate",
+        type=float,
+        default=None,
+        help="Learning rate. If not set, uses a per-model-family default.",
+    )
+
+    parser.add_argument(
+        "--freeze_layers",
+        type=int,
+        default=0,
+        help="Number of bottom transformer layers to freeze.",
+    )
+
+    parser.add_argument(
+        "--per_device_train_batch_size",
+        type=int,
+        default=16,
+        help="Training batch size per device.",
+    )
+
+    parser.add_argument(
+        "--gradient_accumulation_steps",
+        type=int,
+        default=1,
+        help="Gradient accumulation steps (effective batch = batch_size * accumulation).",
+    )
+
+    parser.add_argument(
+        "--early_stopping_patience",
+        type=int,
+        default=50,
+        help="Early stopping patience in epochs. 0 to disable.",
     )
     return parser
 
@@ -55,20 +166,51 @@ def main():
 
     seed = args.seed
     root = args.root
+    data_dir = args.data_dir
     data_augmentation = args.data_augmentation
+    checkpoint = args.checkpoint
+    lr = args.learning_rate if args.learning_rate is not None else get_default_lr(checkpoint)
+    num_freeze = args.freeze_layers
+    batch_size = args.per_device_train_batch_size
+    grad_accum = args.gradient_accumulation_steps
+    es_patience = args.early_stopping_patience
 
     set_seeds(seed=seed)
 
-    if data_augmentation:
-        csmd_dataset = load_dataset("davebulaval/CSMD", "meaning_with_data_augmentation")
+    # Map augmentation variant to directory/HF config names
+    AUGMENTATION_DIR_MAP = {
+        "none": "meaning",
+        "swap": "meaning_with_swap",
+        "back_translation": "meaning_with_back_translation",
+    }
+    AUGMENTATION_HF_MAP = {
+        "none": "meaning",
+        "swap": "meaning_with_data_augmentation",
+    }
+
+    if data_dir is not None:
+        # Load from pre-generated local datasets
+        dataset_path = os.path.join(data_dir, AUGMENTATION_DIR_MAP[data_augmentation])
+        print(f"Loading dataset from disk: {dataset_path}")
+        csmd_dataset = load_from_disk(dataset_path)
+        holdout_identical_dataset = load_from_disk(os.path.join(data_dir, "meaning_holdout_identical"))
+        holdout_unrelated_dataset = load_from_disk(os.path.join(data_dir, "meaning_holdout_unrelated"))
     else:
-        csmd_dataset = load_dataset("davebulaval/CSMD", "meaning")
+        # Fallback: download from HuggingFace Hub (no back_translation available)
+        if data_augmentation == "back_translation":
+            raise ValueError("--data_dir is required for back_translation. Run prepare_datasets.py first.")
+        hf_config = AUGMENTATION_HF_MAP[data_augmentation]
+        print(f"Loading dataset from HuggingFace Hub: davebulaval/CSMD ({hf_config})")
+        csmd_dataset = load_dataset("davebulaval/CSMD", hf_config)
+        holdout_identical_dataset = load_dataset("davebulaval/CSMD", "meaning_holdout_identical")
+        holdout_unrelated_dataset = load_dataset("davebulaval/CSMD", "meaning_holdout_unrelated")
 
-    holdout_identical_dataset = load_dataset("davebulaval/CSMD", "meaning_holdout_identical")
-    holdout_unrelated_dataset = load_dataset("davebulaval/CSMD", "meaning_holdout_unrelated")
-
-    checkpoint = "bert-base-uncased"
     tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+
+    # Decoder-based models (GPT-2, LLaMA, etc.) don't have a pad token by default.
+    # Use eos_token as pad_token for proper batching and padding.
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
 
     def tokenize_function(example):
         return tokenizer(example["original"], example["simplification"], truncation=True, padding=True)
@@ -78,24 +220,43 @@ def main():
     tokenize_holdout_unrelated_dataset = holdout_unrelated_dataset.map(tokenize_function, batched=True)
     data_collator = DataCollatorWithPadding(tokenizer=tokenizer)
 
+    checkpoint_short_name = checkpoint.replace("/", "_")
+    effective_batch = batch_size * grad_accum
+    run_name = f"{checkpoint_short_name}_seed{seed}_lr{lr}_bs{effective_batch}_freeze{num_freeze}_aug{data_augmentation}"
+
     training_args = TrainingArguments(
-        output_dir="meaning_bert_train",
+        output_dir=f"meaning_bert_train_{checkpoint_short_name}",
+        run_name=run_name,
+        report_to="wandb",
         logging_strategy="epoch",
         evaluation_strategy="epoch",
-        per_device_train_batch_size=16,
+        per_device_train_batch_size=batch_size,
         per_device_eval_batch_size=64,
+        gradient_accumulation_steps=grad_accum,
         num_train_epochs=num_epoch,
-        save_total_limit=num_epoch,
+        save_total_limit=3,
         save_strategy="epoch",
-        load_best_model_at_end=True,  # By default, use the eval loss to retrieve the best model.
+        load_best_model_at_end=True,
         seed=seed,
         metric_for_best_model="eval_loss",
-        learning_rate=5e-5,
+        learning_rate=lr,
     )
 
     # num_labels to 1 to create a regression head
     # REF: https://discuss.huggingface.co/t/fine-tune-bert-and-camembert-for-regression-problem/332/17
     model = AutoModelForSequenceClassification.from_pretrained(checkpoint, num_labels=1)
+
+    # Sync model pad_token_id with tokenizer (needed for decoder-based models).
+    if model.config.pad_token_id is None:
+        model.config.pad_token_id = tokenizer.pad_token_id
+
+    # Layer freezing
+    if num_freeze > 0:
+        freeze_layers(model, num_freeze)
+
+    callbacks = []
+    if es_patience > 0:
+        callbacks.append(EarlyStoppingCallback(early_stopping_patience=es_patience))
 
     trainer = Trainer(
         model,
@@ -105,30 +266,64 @@ def main():
         data_collator=data_collator,
         tokenizer=tokenizer,
         compute_metrics=compute_metrics,
+        callbacks=callbacks,
     )
     print("----------Training start----------")
     trainer.train()
 
-    wandb.run.config.update({"data_augmentation": f"{str(data_augmentation)} {num_epoch} holdout fixed"})
+    wandb.run.config.update({
+        "data_augmentation": data_augmentation,
+        "checkpoint": checkpoint,
+        "freeze_layers": num_freeze,
+        "effective_batch_size": effective_batch,
+        "early_stopping_patience": es_patience,
+    })
     wandb.log({"Best model checkpoint path": trainer.state.best_model_checkpoint})
 
     print("----------Test Set Evaluation start----------")
-    trainer.evaluate(eval_dataset=tokenized_csmd_dataset["test"], metric_key_prefix="test")
+    test_results = trainer.evaluate(eval_dataset=tokenized_csmd_dataset["test"], metric_key_prefix="test")
 
     # We change the computed metrics for the holdout splits
     trainer.compute_metrics = eval_compute_metrics_identical
-    trainer.evaluate(
+    identical_results = trainer.evaluate(
         eval_dataset=tokenize_holdout_identical_dataset["test"],
         metric_key_prefix="test/identical_sentences",
     )
 
     trainer.compute_metrics = eval_compute_metrics_unrelated
-    trainer.evaluate(
+    unrelated_results = trainer.evaluate(
         eval_dataset=tokenize_holdout_unrelated_dataset["test"],
         metric_key_prefix="test/unrelated_sentences",
     )
 
-    trainer.save_model(f"meaningbert_best_model_{seed}")
+    # Save best model locally
+    best_model_dir = f"meaningbert_best_model_{checkpoint_short_name}_{seed}"
+    trainer.save_model(best_model_dir)
+    tokenizer.save_pretrained(best_model_dir)
+
+    # Log best model as wandb artifact for later ensemble/deployment
+    artifact = wandb.Artifact(
+        name=f"meaningbert-{checkpoint_short_name}-seed{seed}",
+        type="model",
+        description=f"Best MeaningBERT model fine-tuned from {checkpoint}",
+        metadata={
+            "checkpoint": checkpoint,
+            "seed": seed,
+            "learning_rate": lr,
+            "freeze_layers": num_freeze,
+            "effective_batch_size": effective_batch,
+            "early_stopping_patience": es_patience,
+            "data_augmentation": data_augmentation,
+            "best_checkpoint_path": trainer.state.best_model_checkpoint,
+            "best_eval_loss": trainer.state.best_metric,
+            "test_results": test_results,
+            "holdout_identical_results": identical_results,
+            "holdout_unrelated_results": unrelated_results,
+        },
+    )
+    artifact.add_dir(best_model_dir)
+    wandb.log_artifact(artifact)
+    print(f"Model artifact logged to wandb: meaningbert-{checkpoint_short_name}-seed{seed}")
 
 
 if __name__ == "__main__":

--- a/src/training/few_shot_training.py
+++ b/src/training/few_shot_training.py
@@ -137,8 +137,8 @@ def create_parser() -> argparse.ArgumentParser:
         help="Gradient accumulation steps (effective batch = batch_size * accumulation).",
     )
     parser.add_argument(
-        "--bf16", action="store_true", default=True,
-        help="Use bfloat16 mixed precision (recommended for RTX Ada GPUs).",
+        "--bf16", action=argparse.BooleanOptionalAction, default=True,
+        help="Use bfloat16 mixed precision (recommended for RTX Ada GPUs). Use --no-bf16 to disable.",
     )
     parser.add_argument("--dataloader_num_workers", type=int, default=4, help="Number of dataloader workers.")
     parser.add_argument(

--- a/src/training/launch_sweeps.sh
+++ b/src/training/launch_sweeps.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Launch all 3 GPU sweeps in parallel. Run from src/training/.
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR"
+
+pkill -f sweep_gpu 2>/dev/null
+sleep 1
+
+nohup bash sweep_gpu0.sh > sweep_gpu0.log 2>&1 &
+nohup bash sweep_gpu1.sh > sweep_gpu1.log 2>&1 &
+nohup bash sweep_gpu2.sh > sweep_gpu2.log 2>&1 &
+
+echo "Launched 3 GPU sweeps (PIDs: $(jobs -p | tr '\n' ' '))"
+echo "Monitor: tail -f sweep_gpu0.log sweep_gpu1.log sweep_gpu2.log"

--- a/src/training/metrics/metrics.py
+++ b/src/training/metrics/metrics.py
@@ -6,11 +6,19 @@ r2_metric = load("r_squared")
 pearsonr_metric = load("pearsonr")
 
 
+def _sanitize_predictions(predictions):
+    """Squeeze (N,1)->(N,) and replace NaN/Inf with 0."""
+    predictions = predictions.squeeze()
+    predictions = np.nan_to_num(predictions, nan=0.0, posinf=0.0, neginf=0.0)
+    return predictions
+
+
 def compute_metrics(eval_pred):
     """
     Function to compute various metric during training.
     """
     predictions, labels = eval_pred
+    predictions = _sanitize_predictions(predictions)
     rmse = root_mean_squared_error(labels, predictions)
     r_squared = r2_metric.compute(predictions=predictions, references=labels)
     pearson_corr = pearsonr_metric.compute(predictions=predictions, references=labels, return_pvalue=True)
@@ -36,6 +44,7 @@ def eval_compute_metrics_identical(eval_pred):
     See here for compute details https://huggingface.co/spaces/evaluate-metric/r_squared/edit/main/r_squared.py.
     """
     predictions, labels = eval_pred
+    predictions = _sanitize_predictions(predictions)
     rmse = root_mean_squared_error(labels, predictions)
     mean_score = predictions.mean()
     st_dev_score = predictions.std()
@@ -68,6 +77,7 @@ def eval_compute_metrics_unrelated(eval_pred):
     See here for compute details https://huggingface.co/spaces/evaluate-metric/r_squared/edit/main/r_squared.py.
     """
     predictions, labels = eval_pred
+    predictions = _sanitize_predictions(predictions)
     rmse = root_mean_squared_error(labels, predictions)
     mean_score = predictions.mean()
     st_dev_score = predictions.std()

--- a/src/training/prepare_datasets.py
+++ b/src/training/prepare_datasets.py
@@ -1,0 +1,155 @@
+"""Pre-generate all dataset variants to disk for fast training.
+
+Run once before sweeps:
+    python prepare_datasets.py --output_dir ./data
+
+This creates:
+    data/
+        meaning/                        - base dataset (853 train)
+        meaning_with_swap/              - swap augmentation (4267 train)
+        meaning_with_back_translation/  - swap + back-translation (~12801 train)
+        meaning_holdout_identical/
+        meaning_holdout_unrelated/
+"""
+import argparse
+import os
+
+from datasets import Dataset, DatasetDict, concatenate_datasets, load_dataset
+from transformers import MarianMTModel, MarianTokenizer
+
+
+def back_translate_batch(
+    texts: list[str],
+    en_fr: tuple,
+    fr_en: tuple,
+    batch_size: int = 32,
+) -> list[str]:
+    """Back-translate a list of English texts via French (EN -> FR -> EN)."""
+    en_fr_tokenizer, en_fr_model = en_fr
+    fr_en_tokenizer, fr_en_model = fr_en
+
+    results = []
+    for i in range(0, len(texts), batch_size):
+        batch = texts[i : i + batch_size]
+
+        # EN -> FR
+        inputs = en_fr_tokenizer(batch, return_tensors="pt", padding=True, truncation=True, max_length=512)
+        fr_tokens = en_fr_model.generate(**inputs, max_length=512)
+        fr_texts = en_fr_tokenizer.batch_decode(fr_tokens, skip_special_tokens=True)
+
+        # FR -> EN
+        inputs = fr_en_tokenizer(fr_texts, return_tensors="pt", padding=True, truncation=True, max_length=512)
+        en_tokens = fr_en_model.generate(**inputs, max_length=512)
+        en_texts = fr_en_tokenizer.batch_decode(en_tokens, skip_special_tokens=True)
+
+        results.extend(en_texts)
+        if (i // batch_size) % 10 == 0:
+            print(f"    Batch {i // batch_size + 1}/{(len(texts) + batch_size - 1) // batch_size}")
+
+    return results
+
+
+def create_back_translated_split(dataset, en_fr, fr_en, batch_size: int = 32) -> Dataset:
+    """Add back-translated pairs to a dataset split."""
+    originals = dataset["original"]
+    simplifications = dataset["simplification"]
+    labels = dataset["label"]
+
+    print(f"  Back-translating {len(originals)} originals...")
+    bt_originals = back_translate_batch(originals, en_fr, fr_en, batch_size)
+
+    print(f"  Back-translating {len(simplifications)} simplifications...")
+    bt_simplifications = back_translate_batch(simplifications, en_fr, fr_en, batch_size)
+
+    augmented = Dataset.from_dict({
+        "original": bt_originals + originals,
+        "simplification": simplifications + bt_simplifications,
+        "label": labels + labels,
+    })
+
+    return concatenate_datasets([dataset, augmented])
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Pre-generate all CSMD dataset variants to disk.")
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="./data",
+        help="Root directory for all dataset variants.",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=32,
+        help="Batch size for back-translation.",
+    )
+    parser.add_argument(
+        "--skip_back_translation",
+        action="store_true",
+        help="Skip back-translation (only prepare base + swap + holdouts).",
+    )
+    args = parser.parse_args()
+
+    output_dir = args.output_dir
+    os.makedirs(output_dir, exist_ok=True)
+
+    # 1. Base dataset (no augmentation)
+    print("=== Downloading base dataset ===")
+    meaning = load_dataset("davebulaval/CSMD", "meaning")
+    meaning_path = os.path.join(output_dir, "meaning")
+    meaning.save_to_disk(meaning_path)
+    print(f"  Saved to {meaning_path} (train={len(meaning['train'])})")
+
+    # 2. Swap augmentation (commutative property)
+    print("\n=== Downloading swap-augmented dataset ===")
+    meaning_swap = load_dataset("davebulaval/CSMD", "meaning_with_data_augmentation")
+    meaning_swap_path = os.path.join(output_dir, "meaning_with_swap")
+    meaning_swap.save_to_disk(meaning_swap_path)
+    print(f"  Saved to {meaning_swap_path} (train={len(meaning_swap['train'])})")
+
+    # 3. Back-translation on top of swap
+    if not args.skip_back_translation:
+        print("\n=== Loading translation models ===")
+        en_fr_tokenizer = MarianTokenizer.from_pretrained("Helsinki-NLP/opus-mt-en-fr")
+        en_fr_model = MarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-en-fr")
+        fr_en_tokenizer = MarianTokenizer.from_pretrained("Helsinki-NLP/opus-mt-fr-en")
+        fr_en_model = MarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-fr-en")
+        en_fr = (en_fr_tokenizer, en_fr_model)
+        fr_en = (fr_en_tokenizer, fr_en_model)
+
+        print("\n=== Generating back-translated dataset ===")
+        bt_train = create_back_translated_split(meaning_swap["train"], en_fr, fr_en, args.batch_size)
+        meaning_bt = DatasetDict({
+            "train": bt_train,
+            "dev": meaning_swap["dev"],
+            "test": meaning_swap["test"],
+        })
+        meaning_bt_path = os.path.join(output_dir, "meaning_with_back_translation")
+        meaning_bt.save_to_disk(meaning_bt_path)
+        print(f"  Saved to {meaning_bt_path} (train={len(bt_train)})")
+    else:
+        print("\n=== Skipping back-translation ===")
+
+    # 4. Holdout datasets
+    print("\n=== Downloading holdout datasets ===")
+    holdout_identical = load_dataset("davebulaval/CSMD", "meaning_holdout_identical")
+    holdout_identical_path = os.path.join(output_dir, "meaning_holdout_identical")
+    holdout_identical.save_to_disk(holdout_identical_path)
+    print(f"  Saved to {holdout_identical_path} (test={len(holdout_identical['test'])})")
+
+    holdout_unrelated = load_dataset("davebulaval/CSMD", "meaning_holdout_unrelated")
+    holdout_unrelated_path = os.path.join(output_dir, "meaning_holdout_unrelated")
+    holdout_unrelated.save_to_disk(holdout_unrelated_path)
+    print(f"  Saved to {holdout_unrelated_path} (test={len(holdout_unrelated['test'])})")
+
+    print("\n=== Done ===")
+    print(f"All datasets saved to {output_dir}/")
+    for name in sorted(os.listdir(output_dir)):
+        full = os.path.join(output_dir, name)
+        if os.path.isdir(full):
+            print(f"  {name}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/training/prepare_datasets.py
+++ b/src/training/prepare_datasets.py
@@ -1,21 +1,26 @@
 """Pre-generate all dataset variants to disk for fast training.
 
-Run once before sweeps:
+Run once before sweeps::
+
     python prepare_datasets.py --output_dir ./data
 
-This creates:
+This creates::
+
     data/
         folds/
-            fold_0/                         - seed 42 split
-                meaning/                    - base (no augmentation)
-                meaning_with_swap/          - swap augmentation
-                meaning_with_back_translation/ - swap + back-translation
-            fold_1/                         - seed 43 split
+            fold_0/                             - seed 42, stratified split
+                meaning/                        - base (no augmentation)
+                meaning_with_swap/              - swap augmentation (skip identical)
+                meaning_with_back_translation/  - swap + back-translation
+            fold_1/                             - seed 43, stratified split
                 ...
-            ...
-        meaning_holdout_identical/
-        meaning_holdout_unrelated/
+
+Corpus: base (1355) + identical (359, score=100) + unrelated (359, score=0) = 2073 examples.
+Each fold is stratified on source type (original/identical/unrelated).
+Swap skips identical pairs. Back-translation done once on GPU, reused across folds.
 """
+from __future__ import annotations
+
 import argparse
 import os
 
@@ -25,49 +30,84 @@ from sklearn.model_selection import train_test_split
 from tqdm import tqdm
 from transformers import MarianMTModel, MarianTokenizer
 
-
-FOLD_SEEDS = [42, 43, 44, 45, 46, 47, 48, 49, 50, 51]
+FOLD_SEEDS: list[int] = [42, 43, 44, 45, 46, 47, 48, 49, 50, 51]
 
 
 def get_device() -> torch.device:
+    """Return CUDA device if available, else CPU."""
     if torch.cuda.is_available():
         return torch.device("cuda")
     return torch.device("cpu")
 
 
+@torch.inference_mode()
+def _translate_batch(
+    batch: list[str],
+    tokenizer: MarianTokenizer,
+    model: MarianMTModel,
+    device: torch.device,
+) -> list[str]:
+    """Translate a single batch of texts."""
+    inputs = tokenizer(batch, return_tensors="pt", padding=True, truncation=True, max_length=512).to(device)
+    tokens = model.generate(**inputs, max_length=512)
+    return tokenizer.batch_decode(tokens, skip_special_tokens=True)
+
+
 def back_translate_batch(
     texts: list[str],
-    en_fr: tuple,
-    fr_en: tuple,
+    en_fr: tuple[MarianTokenizer, MarianMTModel],
+    fr_en: tuple[MarianTokenizer, MarianMTModel],
     device: torch.device,
     batch_size: int = 32,
 ) -> list[str]:
-    """Back-translate a list of English texts via French (EN -> FR -> EN)."""
+    """Back-translate a list of English texts via French (EN -> FR -> EN).
+
+    Args:
+        texts: English sentences to paraphrase.
+        en_fr: (tokenizer, model) for EN->FR.
+        fr_en: (tokenizer, model) for FR->EN.
+        device: Torch device for inference.
+        batch_size: Number of sentences per batch.
+
+    Returns:
+        Back-translated English sentences.
+    """
     en_fr_tokenizer, en_fr_model = en_fr
     fr_en_tokenizer, fr_en_model = fr_en
 
-    results = []
+    results: list[str] = []
     num_batches = (len(texts) + batch_size - 1) // batch_size
     for i in tqdm(range(0, len(texts), batch_size), total=num_batches, desc="    Back-translating"):
         batch = texts[i : i + batch_size]
-
-        # EN -> FR
-        inputs = en_fr_tokenizer(batch, return_tensors="pt", padding=True, truncation=True, max_length=512).to(device)
-        fr_tokens = en_fr_model.generate(**inputs, max_length=512)
-        fr_texts = en_fr_tokenizer.batch_decode(fr_tokens, skip_special_tokens=True)
-
-        # FR -> EN
-        inputs = fr_en_tokenizer(fr_texts, return_tensors="pt", padding=True, truncation=True, max_length=512).to(device)
-        en_tokens = fr_en_model.generate(**inputs, max_length=512)
-        en_texts = fr_en_tokenizer.batch_decode(en_tokens, skip_special_tokens=True)
-
+        fr_texts = _translate_batch(batch, en_fr_tokenizer, en_fr_model, device)
+        en_texts = _translate_batch(fr_texts, fr_en_tokenizer, fr_en_model, device)
         results.extend(en_texts)
 
     return results
 
 
-def back_translate_dataset(dataset: Dataset, en_fr, fr_en, device, batch_size: int = 32) -> Dataset:
-    """Add back-translated pairs to a dataset. Tags new pairs with source='back_translated'."""
+def back_translate_dataset(
+    dataset: Dataset,
+    en_fr: tuple[MarianTokenizer, MarianMTModel],
+    fr_en: tuple[MarianTokenizer, MarianMTModel],
+    device: torch.device,
+    batch_size: int = 32,
+) -> Dataset:
+    """Add back-translated pairs to a dataset.
+
+    For each example (A, B, label), creates two new pairs:
+    (bt_A, B, label) and (A, bt_B, label). Tags new pairs with source='back_translated'.
+
+    Args:
+        dataset: HF Dataset with columns 'original', 'simplification', 'label'.
+        en_fr: (tokenizer, model) for EN->FR.
+        fr_en: (tokenizer, model) for FR->EN.
+        device: Torch device for inference.
+        batch_size: Number of sentences per batch.
+
+    Returns:
+        Concatenated dataset: original rows + back-translated rows.
+    """
     originals = list(dataset["original"])
     simplifications = list(dataset["simplification"])
     labels = list(dataset["label"])
@@ -85,7 +125,7 @@ def back_translate_dataset(dataset: Dataset, en_fr, fr_en, device, batch_size: i
         "source": ["back_translated"] * (len(originals) * 2),
     })
 
-    # Tag original rows
+    # Ensure original rows are tagged
     if "source" not in dataset.column_names:
         dataset = dataset.add_column("source", ["original"] * len(dataset))
 
@@ -93,21 +133,30 @@ def back_translate_dataset(dataset: Dataset, en_fr, fr_en, device, batch_size: i
 
 
 def apply_commutative_swap(dataset: Dataset) -> Dataset:
-    """Apply commutative property: Meaning(a,b) = Meaning(b,a).
+    """Apply commutative property: Meaning(a, b) = Meaning(b, a).
 
     Skips identical pairs (swapping identical sentences is a no-op).
+
+    Args:
+        dataset: HF Dataset with columns 'original', 'simplification', 'label'
+                 and optionally 'source'.
+
+    Returns:
+        Concatenated dataset: original rows + swapped rows.
     """
     originals = list(dataset["original"])
     simplifications = list(dataset["simplification"])
     labels = list(dataset["label"])
     sources = list(dataset["source"]) if "source" in dataset.column_names else ["original"] * len(originals)
 
-    # Tag original rows if not already tagged
+    # Ensure source column exists
     if "source" not in dataset.column_names:
         dataset = dataset.add_column("source", sources)
 
     # Only swap non-identical pairs
-    swap_orig, swap_simp, swap_labels = [], [], []
+    swap_orig: list[str] = []
+    swap_simp: list[str] = []
+    swap_labels: list[float] = []
     for orig, simp, label, src in zip(originals, simplifications, labels, sources):
         if src == "identical":
             continue
@@ -132,7 +181,18 @@ def create_fold_splits(
     dev_ratio: float = 0.1,
     test_ratio: float = 0.3,
 ) -> DatasetDict:
-    """Split a dataset into train/dev/test with stratification on source type."""
+    """Split a dataset into train/dev/test with stratification.
+
+    Args:
+        full_dataset: Complete dataset to split.
+        seed: Random seed for reproducibility.
+        stratify_column: Column name to stratify on.
+        dev_ratio: Proportion of data for dev set (relative to total).
+        test_ratio: Proportion of data for test set.
+
+    Returns:
+        DatasetDict with 'train', 'dev', 'test' splits.
+    """
     indices = list(range(len(full_dataset)))
     strata = full_dataset[stratify_column]
 
@@ -152,35 +212,17 @@ def create_fold_splits(
     })
 
 
-def main():
+def main() -> None:
+    """Pre-generate all CSMD dataset variants (base, swap, back-translation) across k folds."""
     parser = argparse.ArgumentParser(description="Pre-generate all CSMD dataset variants to disk.")
-    parser.add_argument(
-        "--output_dir",
-        type=str,
-        default="./data",
-        help="Root directory for all dataset variants.",
-    )
-    parser.add_argument(
-        "--batch_size",
-        type=int,
-        default=32,
-        help="Batch size for back-translation.",
-    )
-    parser.add_argument(
-        "--skip_back_translation",
-        action="store_true",
-        help="Skip back-translation (only prepare base + swap + holdouts).",
-    )
-    parser.add_argument(
-        "--num_folds",
-        type=int,
-        default=10,
-        help="Number of k-fold splits to generate.",
-    )
+    parser.add_argument("--output_dir", type=str, default="./data", help="Root directory for all dataset variants.")
+    parser.add_argument("--batch_size", type=int, default=128, help="Batch size for back-translation.")
+    parser.add_argument("--skip_back_translation", action="store_true", help="Skip back-translation.")
+    parser.add_argument("--num_folds", type=int, default=10, help="Number of k-fold splits to generate.")
     args = parser.parse_args()
 
-    output_dir = args.output_dir
-    num_folds = args.num_folds
+    output_dir: str = args.output_dir
+    num_folds: int = args.num_folds
     os.makedirs(output_dir, exist_ok=True)
 
     device = get_device()
@@ -203,13 +245,13 @@ def main():
     print(f"    original: {len(meaning_pool)}, identical: {len(holdout_identical)}, unrelated: {len(holdout_unrelated)}")
 
     # Back-translate the full corpus once (before splitting into folds)
-    bt_full_dataset = None
+    bt_full_dataset: Dataset | None = None
     if not args.skip_back_translation:
         print("\n=== Loading translation models ===")
         en_fr_tokenizer = MarianTokenizer.from_pretrained("Helsinki-NLP/opus-mt-en-fr")
-        en_fr_model = MarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-en-fr").to(device)
+        en_fr_model = MarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-en-fr", torch_dtype=torch.bfloat16).to(device)
         fr_en_tokenizer = MarianTokenizer.from_pretrained("Helsinki-NLP/opus-mt-fr-en")
-        fr_en_model = MarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-fr-en").to(device)
+        fr_en_model = MarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-fr-en", torch_dtype=torch.bfloat16).to(device)
         en_fr = (en_fr_tokenizer, en_fr_model)
         fr_en = (fr_en_tokenizer, fr_en_model)
 
@@ -246,10 +288,9 @@ def main():
         swap_path = os.path.join(fold_dir, "meaning_with_swap")
         swap_splits.save_to_disk(swap_path)
 
-        # 3. Back-translation - stratified split of the pre-computed bt corpus
+        # 3. Back-translation - stratified split of the pre-computed bt corpus, then swap on train
         if bt_full_dataset is not None:
             bt_splits = create_fold_splits(bt_full_dataset, seed, stratify_column="source")
-            # Apply swap on bt train too
             bt_swap_splits = DatasetDict({
                 "train": apply_commutative_swap(bt_splits["train"]),
                 "dev": bt_splits["dev"],
@@ -259,7 +300,7 @@ def main():
             bt_swap_splits.save_to_disk(bt_path)
 
         # Stats
-        source_counts = {}
+        source_counts: dict[str, int] = {}
         for src in base_splits["train"]["source"]:
             source_counts[src] = source_counts.get(src, 0) + 1
         print(f"  Fold {fold_idx} (seed={seed}): "

--- a/src/training/prepare_datasets.py
+++ b/src/training/prepare_datasets.py
@@ -93,11 +93,14 @@ def back_translate_dataset(
     fr_en: tuple[MarianTokenizer, MarianMTModel],
     device: torch.device,
     batch_size: int = 32,
+    exclude_fingerprints: set[str] | None = None,
 ) -> Dataset:
     """Add back-translated pairs to a dataset.
 
     For each example (A, B, label), creates two new pairs:
     (bt_A, B, label) and (A, bt_B, label). Tags new pairs with source='back_translated'.
+    Pairs whose (original, simplification) fingerprint appears in *exclude_fingerprints*
+    are dropped to prevent data leakage into dev/test.
 
     Args:
         dataset: HF Dataset with columns 'original', 'simplification', 'label'.
@@ -105,9 +108,10 @@ def back_translate_dataset(
         fr_en: (tokenizer, model) for FR->EN.
         device: Torch device for inference.
         batch_size: Number of sentences per batch.
+        exclude_fingerprints: Set of "original|||simplification" strings to exclude.
 
     Returns:
-        Concatenated dataset: original rows + back-translated rows.
+        Concatenated dataset: original rows + back-translated rows (deduplicated).
     """
     originals = list(dataset["original"])
     simplifications = list(dataset["simplification"])
@@ -119,11 +123,31 @@ def back_translate_dataset(
     print(f"  Back-translating {len(simplifications)} simplifications...")
     bt_simplifications = back_translate_batch(simplifications, en_fr, fr_en, device, batch_size)
 
+    # Build augmented pairs: (bt_orig, simp) and (orig, bt_simp)
+    aug_orig = bt_originals + originals
+    aug_simp = simplifications + bt_simplifications
+    aug_labels = labels + labels
+
+    # Filter out pairs that collide with dev/test fingerprints
+    if exclude_fingerprints:
+        keep_orig, keep_simp, keep_labels = [], [], []
+        n_dropped = 0
+        for o, s, l in zip(aug_orig, aug_simp, aug_labels):
+            if f"{o}|||{s}" in exclude_fingerprints:
+                n_dropped += 1
+            else:
+                keep_orig.append(o)
+                keep_simp.append(s)
+                keep_labels.append(l)
+        if n_dropped > 0:
+            print(f"  Dropped {n_dropped} bt pairs colliding with dev/test")
+        aug_orig, aug_simp, aug_labels = keep_orig, keep_simp, keep_labels
+
     augmented = Dataset.from_dict({
-        "original": bt_originals + originals,
-        "simplification": simplifications + bt_simplifications,
-        "label": labels + labels,
-        "source": ["back_translated"] * (len(originals) * 2),
+        "original": aug_orig,
+        "simplification": aug_simp,
+        "label": aug_labels,
+        "source": ["back_translated"] * len(aug_orig),
     })
 
     # Ensure original rows are tagged
@@ -297,8 +321,17 @@ def main() -> None:
 
         # 3. Back-translation on TRAIN ONLY, then swap. Dev/test stay clean.
         if en_fr is not None and fr_en is not None:
+            # Build fingerprints of dev+test to exclude colliding bt pairs
+            dev_test_fps: set[str] = set()
+            for split in ["dev", "test"]:
+                for o, s in zip(base_splits[split]["original"], base_splits[split]["simplification"]):
+                    dev_test_fps.add(f"{o}|||{s}")
+
             print(f"\n  Back-translating fold {fold_idx} train ({len(base_splits['train'])} examples)...")
-            bt_train = back_translate_dataset(base_splits["train"], en_fr, fr_en, device, args.batch_size)
+            bt_train = back_translate_dataset(
+                base_splits["train"], en_fr, fr_en, device, args.batch_size,
+                exclude_fingerprints=dev_test_fps,
+            )
             bt_train_swapped = apply_commutative_swap(bt_train)
             bt_splits = DatasetDict({
                 "train": bt_train_swapped,

--- a/src/training/prepare_datasets.py
+++ b/src/training/prepare_datasets.py
@@ -327,12 +327,30 @@ def main() -> None:
                 for o, s in zip(base_splits[split]["original"], base_splits[split]["simplification"]):
                     dev_test_fps.add(f"{o}|||{s}")
 
+            # Also add reversed fingerprints for swap dedup
+            for o, s in zip(base_splits["dev"]["original"], base_splits["dev"]["simplification"]):
+                dev_test_fps.add(f"{s}|||{o}")
+            for o, s in zip(base_splits["test"]["original"], base_splits["test"]["simplification"]):
+                dev_test_fps.add(f"{s}|||{o}")
+
             print(f"\n  Back-translating fold {fold_idx} train ({len(base_splits['train'])} examples)...")
             bt_train = back_translate_dataset(
                 base_splits["train"], en_fr, fr_en, device, args.batch_size,
                 exclude_fingerprints=dev_test_fps,
             )
             bt_train_swapped = apply_commutative_swap(bt_train)
+
+            # Final dedup of swapped bt pairs against dev/test
+            keep_indices = [
+                i for i, (o, s) in enumerate(
+                    zip(bt_train_swapped["original"], bt_train_swapped["simplification"])
+                )
+                if f"{o}|||{s}" not in dev_test_fps
+            ]
+            if len(keep_indices) < len(bt_train_swapped):
+                n_dropped = len(bt_train_swapped) - len(keep_indices)
+                print(f"  Dropped {n_dropped} swapped pairs colliding with dev/test")
+                bt_train_swapped = bt_train_swapped.select(keep_indices)
             bt_splits = DatasetDict({
                 "train": bt_train_swapped,
                 "dev": base_splits["dev"],

--- a/src/training/prepare_datasets.py
+++ b/src/training/prepare_datasets.py
@@ -51,9 +51,9 @@ def back_translate_batch(
 
 def create_back_translated_split(dataset, en_fr, fr_en, batch_size: int = 32) -> Dataset:
     """Add back-translated pairs to a dataset split."""
-    originals = dataset["original"]
-    simplifications = dataset["simplification"]
-    labels = dataset["label"]
+    originals = list(dataset["original"])
+    simplifications = list(dataset["simplification"])
+    labels = list(dataset["label"])
 
     print(f"  Back-translating {len(originals)} originals...")
     bt_originals = back_translate_batch(originals, en_fr, fr_en, batch_size)

--- a/src/training/prepare_datasets.py
+++ b/src/training/prepare_datasets.py
@@ -15,6 +15,7 @@ import argparse
 import os
 
 from datasets import Dataset, DatasetDict, concatenate_datasets, load_dataset
+from tqdm import tqdm
 from transformers import MarianMTModel, MarianTokenizer
 
 
@@ -29,7 +30,8 @@ def back_translate_batch(
     fr_en_tokenizer, fr_en_model = fr_en
 
     results = []
-    for i in range(0, len(texts), batch_size):
+    num_batches = (len(texts) + batch_size - 1) // batch_size
+    for i in tqdm(range(0, len(texts), batch_size), total=num_batches, desc="    Back-translating"):
         batch = texts[i : i + batch_size]
 
         # EN -> FR
@@ -43,8 +45,6 @@ def back_translate_batch(
         en_texts = fr_en_tokenizer.batch_decode(en_tokens, skip_special_tokens=True)
 
         results.extend(en_texts)
-        if (i // batch_size) % 10 == 0:
-            print(f"    Batch {i // batch_size + 1}/{(len(texts) + batch_size - 1) // batch_size}")
 
     return results
 

--- a/src/training/prepare_datasets.py
+++ b/src/training/prepare_datasets.py
@@ -5,24 +5,41 @@ Run once before sweeps:
 
 This creates:
     data/
-        meaning/                        - base dataset (853 train)
-        meaning_with_swap/              - swap augmentation (4267 train)
-        meaning_with_back_translation/  - swap + back-translation (~12801 train)
+        folds/
+            fold_0/                         - seed 42 split
+                meaning/                    - base (no augmentation)
+                meaning_with_swap/          - swap augmentation
+                meaning_with_back_translation/ - swap + back-translation
+            fold_1/                         - seed 43 split
+                ...
+            ...
         meaning_holdout_identical/
         meaning_holdout_unrelated/
 """
 import argparse
 import os
 
+import torch
 from datasets import Dataset, DatasetDict, concatenate_datasets, load_dataset
+from sklearn.model_selection import train_test_split
 from tqdm import tqdm
 from transformers import MarianMTModel, MarianTokenizer
+
+
+FOLD_SEEDS = [42, 43, 44, 45, 46, 47, 48, 49, 50, 51]
+
+
+def get_device() -> torch.device:
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
 
 
 def back_translate_batch(
     texts: list[str],
     en_fr: tuple,
     fr_en: tuple,
+    device: torch.device,
     batch_size: int = 32,
 ) -> list[str]:
     """Back-translate a list of English texts via French (EN -> FR -> EN)."""
@@ -35,12 +52,12 @@ def back_translate_batch(
         batch = texts[i : i + batch_size]
 
         # EN -> FR
-        inputs = en_fr_tokenizer(batch, return_tensors="pt", padding=True, truncation=True, max_length=512)
+        inputs = en_fr_tokenizer(batch, return_tensors="pt", padding=True, truncation=True, max_length=512).to(device)
         fr_tokens = en_fr_model.generate(**inputs, max_length=512)
         fr_texts = en_fr_tokenizer.batch_decode(fr_tokens, skip_special_tokens=True)
 
         # FR -> EN
-        inputs = fr_en_tokenizer(fr_texts, return_tensors="pt", padding=True, truncation=True, max_length=512)
+        inputs = fr_en_tokenizer(fr_texts, return_tensors="pt", padding=True, truncation=True, max_length=512).to(device)
         en_tokens = fr_en_model.generate(**inputs, max_length=512)
         en_texts = fr_en_tokenizer.batch_decode(en_tokens, skip_special_tokens=True)
 
@@ -49,25 +66,90 @@ def back_translate_batch(
     return results
 
 
-def create_back_translated_split(dataset, en_fr, fr_en, batch_size: int = 32) -> Dataset:
-    """Add back-translated pairs to a dataset split."""
+def back_translate_dataset(dataset: Dataset, en_fr, fr_en, device, batch_size: int = 32) -> Dataset:
+    """Add back-translated pairs to a dataset. Tags new pairs with source='back_translated'."""
     originals = list(dataset["original"])
     simplifications = list(dataset["simplification"])
     labels = list(dataset["label"])
 
     print(f"  Back-translating {len(originals)} originals...")
-    bt_originals = back_translate_batch(originals, en_fr, fr_en, batch_size)
+    bt_originals = back_translate_batch(originals, en_fr, fr_en, device, batch_size)
 
     print(f"  Back-translating {len(simplifications)} simplifications...")
-    bt_simplifications = back_translate_batch(simplifications, en_fr, fr_en, batch_size)
+    bt_simplifications = back_translate_batch(simplifications, en_fr, fr_en, device, batch_size)
 
     augmented = Dataset.from_dict({
         "original": bt_originals + originals,
         "simplification": simplifications + bt_simplifications,
         "label": labels + labels,
+        "source": ["back_translated"] * (len(originals) * 2),
     })
 
+    # Tag original rows
+    if "source" not in dataset.column_names:
+        dataset = dataset.add_column("source", ["original"] * len(dataset))
+
     return concatenate_datasets([dataset, augmented])
+
+
+def apply_commutative_swap(dataset: Dataset) -> Dataset:
+    """Apply commutative property: Meaning(a,b) = Meaning(b,a).
+
+    Skips identical pairs (swapping identical sentences is a no-op).
+    """
+    originals = list(dataset["original"])
+    simplifications = list(dataset["simplification"])
+    labels = list(dataset["label"])
+    sources = list(dataset["source"]) if "source" in dataset.column_names else ["original"] * len(originals)
+
+    # Tag original rows if not already tagged
+    if "source" not in dataset.column_names:
+        dataset = dataset.add_column("source", sources)
+
+    # Only swap non-identical pairs
+    swap_orig, swap_simp, swap_labels = [], [], []
+    for orig, simp, label, src in zip(originals, simplifications, labels, sources):
+        if src == "identical":
+            continue
+        swap_orig.append(simp)
+        swap_simp.append(orig)
+        swap_labels.append(label)
+
+    swapped = Dataset.from_dict({
+        "original": swap_orig,
+        "simplification": swap_simp,
+        "label": swap_labels,
+        "source": ["swapped"] * len(swap_orig),
+    })
+
+    return concatenate_datasets([dataset, swapped])
+
+
+def create_fold_splits(
+    full_dataset: Dataset,
+    seed: int,
+    stratify_column: str = "source",
+    dev_ratio: float = 0.1,
+    test_ratio: float = 0.3,
+) -> DatasetDict:
+    """Split a dataset into train/dev/test with stratification on source type."""
+    indices = list(range(len(full_dataset)))
+    strata = full_dataset[stratify_column]
+
+    train_dev_idx, test_idx = train_test_split(
+        indices, test_size=test_ratio, random_state=seed, stratify=strata,
+    )
+    relative_dev_ratio = dev_ratio / (1 - test_ratio)
+    train_dev_strata = [strata[i] for i in train_dev_idx]
+    train_idx, dev_idx = train_test_split(
+        train_dev_idx, test_size=relative_dev_ratio, random_state=seed, stratify=train_dev_strata,
+    )
+
+    return DatasetDict({
+        "train": full_dataset.select(train_idx),
+        "dev": full_dataset.select(dev_idx),
+        "test": full_dataset.select(test_idx),
+    })
 
 
 def main():
@@ -89,66 +171,110 @@ def main():
         action="store_true",
         help="Skip back-translation (only prepare base + swap + holdouts).",
     )
+    parser.add_argument(
+        "--num_folds",
+        type=int,
+        default=10,
+        help="Number of k-fold splits to generate.",
+    )
     args = parser.parse_args()
 
     output_dir = args.output_dir
+    num_folds = args.num_folds
     os.makedirs(output_dir, exist_ok=True)
 
-    # 1. Base dataset (no augmentation)
-    print("=== Downloading base dataset ===")
-    meaning = load_dataset("davebulaval/CSMD", "meaning")
-    meaning_path = os.path.join(output_dir, "meaning")
-    meaning.save_to_disk(meaning_path)
-    print(f"  Saved to {meaning_path} (train={len(meaning['train'])})")
+    device = get_device()
+    print(f"Using device: {device}")
 
-    # 2. Swap augmentation (commutative property)
-    print("\n=== Downloading swap-augmented dataset ===")
-    meaning_swap = load_dataset("davebulaval/CSMD", "meaning_with_data_augmentation")
-    meaning_swap_path = os.path.join(output_dir, "meaning_with_swap")
-    meaning_swap.save_to_disk(meaning_swap_path)
-    print(f"  Saved to {meaning_swap_path} (train={len(meaning_swap['train'])})")
+    # Load and merge all data sources into one corpus with source tags
+    print("=== Downloading datasets ===")
+    meaning_raw = load_dataset("davebulaval/CSMD", "meaning")
+    meaning_pool = concatenate_datasets([meaning_raw["train"], meaning_raw["dev"], meaning_raw["test"]])
+    meaning_pool = meaning_pool.add_column("source", ["original"] * len(meaning_pool))
 
-    # 3. Back-translation on top of swap
+    holdout_identical = load_dataset("davebulaval/CSMD", "meaning_holdout_identical")["test"]
+    holdout_identical = holdout_identical.add_column("source", ["identical"] * len(holdout_identical))
+
+    holdout_unrelated = load_dataset("davebulaval/CSMD", "meaning_holdout_unrelated")["test"]
+    holdout_unrelated = holdout_unrelated.add_column("source", ["unrelated"] * len(holdout_unrelated))
+
+    full_dataset = concatenate_datasets([meaning_pool, holdout_identical, holdout_unrelated])
+    print(f"  Full corpus: {len(full_dataset)} examples")
+    print(f"    original: {len(meaning_pool)}, identical: {len(holdout_identical)}, unrelated: {len(holdout_unrelated)}")
+
+    # Back-translate the full corpus once (before splitting into folds)
+    bt_full_dataset = None
     if not args.skip_back_translation:
         print("\n=== Loading translation models ===")
         en_fr_tokenizer = MarianTokenizer.from_pretrained("Helsinki-NLP/opus-mt-en-fr")
-        en_fr_model = MarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-en-fr")
+        en_fr_model = MarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-en-fr").to(device)
         fr_en_tokenizer = MarianTokenizer.from_pretrained("Helsinki-NLP/opus-mt-fr-en")
-        fr_en_model = MarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-fr-en")
+        fr_en_model = MarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-fr-en").to(device)
         en_fr = (en_fr_tokenizer, en_fr_model)
         fr_en = (fr_en_tokenizer, fr_en_model)
 
-        print("\n=== Generating back-translated dataset ===")
-        bt_train = create_back_translated_split(meaning_swap["train"], en_fr, fr_en, args.batch_size)
-        meaning_bt = DatasetDict({
-            "train": bt_train,
-            "dev": meaning_swap["dev"],
-            "test": meaning_swap["test"],
-        })
-        meaning_bt_path = os.path.join(output_dir, "meaning_with_back_translation")
-        meaning_bt.save_to_disk(meaning_bt_path)
-        print(f"  Saved to {meaning_bt_path} (train={len(bt_train)})")
+        print("\n=== Back-translating full corpus (done once, reused across folds) ===")
+        bt_full_dataset = back_translate_dataset(full_dataset, en_fr, fr_en, device, args.batch_size)
+        print(f"  Back-translated corpus: {len(bt_full_dataset)} examples")
+
+        # Free GPU memory
+        del en_fr_model, fr_en_model
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
     else:
         print("\n=== Skipping back-translation ===")
 
-    # 4. Holdout datasets
-    print("\n=== Downloading holdout datasets ===")
-    holdout_identical = load_dataset("davebulaval/CSMD", "meaning_holdout_identical")
-    holdout_identical_path = os.path.join(output_dir, "meaning_holdout_identical")
-    holdout_identical.save_to_disk(holdout_identical_path)
-    print(f"  Saved to {holdout_identical_path} (test={len(holdout_identical['test'])})")
+    # Generate k-fold splits (stratified on source type)
+    print(f"\n=== Generating {num_folds} stratified folds ===")
+    fold_seeds = FOLD_SEEDS[:num_folds]
 
-    holdout_unrelated = load_dataset("davebulaval/CSMD", "meaning_holdout_unrelated")
-    holdout_unrelated_path = os.path.join(output_dir, "meaning_holdout_unrelated")
-    holdout_unrelated.save_to_disk(holdout_unrelated_path)
-    print(f"  Saved to {holdout_unrelated_path} (test={len(holdout_unrelated['test'])})")
+    for fold_idx, seed in enumerate(tqdm(fold_seeds, desc="Generating folds")):
+        fold_dir = os.path.join(output_dir, "folds", f"fold_{fold_idx}")
+        os.makedirs(fold_dir, exist_ok=True)
+
+        # 1. Base (no augmentation) - stratified split
+        base_splits = create_fold_splits(full_dataset, seed, stratify_column="source")
+        base_path = os.path.join(fold_dir, "meaning")
+        base_splits.save_to_disk(base_path)
+
+        # 2. Swap (commutative property) - applied only on train
+        swap_splits = DatasetDict({
+            "train": apply_commutative_swap(base_splits["train"]),
+            "dev": base_splits["dev"],
+            "test": base_splits["test"],
+        })
+        swap_path = os.path.join(fold_dir, "meaning_with_swap")
+        swap_splits.save_to_disk(swap_path)
+
+        # 3. Back-translation - stratified split of the pre-computed bt corpus
+        if bt_full_dataset is not None:
+            bt_splits = create_fold_splits(bt_full_dataset, seed, stratify_column="source")
+            # Apply swap on bt train too
+            bt_swap_splits = DatasetDict({
+                "train": apply_commutative_swap(bt_splits["train"]),
+                "dev": bt_splits["dev"],
+                "test": bt_splits["test"],
+            })
+            bt_path = os.path.join(fold_dir, "meaning_with_back_translation")
+            bt_swap_splits.save_to_disk(bt_path)
+
+        # Stats
+        source_counts = {}
+        for src in base_splits["train"]["source"]:
+            source_counts[src] = source_counts.get(src, 0) + 1
+        print(f"  Fold {fold_idx} (seed={seed}): "
+              f"train={len(base_splits['train'])} {source_counts}, "
+              f"dev={len(base_splits['dev'])}, "
+              f"test={len(base_splits['test'])}")
 
     print("\n=== Done ===")
     print(f"All datasets saved to {output_dir}/")
-    for name in sorted(os.listdir(output_dir)):
-        full = os.path.join(output_dir, name)
-        if os.path.isdir(full):
-            print(f"  {name}/")
+    print(f"Structure:")
+    print(f"  folds/ ({num_folds} folds)")
+    for fold_idx in range(num_folds):
+        fold_dir = os.path.join(output_dir, "folds", f"fold_{fold_idx}")
+        variants = [d for d in sorted(os.listdir(fold_dir)) if os.path.isdir(os.path.join(fold_dir, d))]
+        print(f"    fold_{fold_idx}/ -> {', '.join(variants)}")
 
 
 if __name__ == "__main__":

--- a/src/training/prepare_datasets.py
+++ b/src/training/prepare_datasets.py
@@ -15,9 +15,10 @@ This creates::
             fold_1/                             - seed 43, stratified split
                 ...
 
-Corpus: base (1355) + identical (359, score=100) + unrelated (359, score=0) = 2073 examples.
+Corpus: base (1355) + identical (359, score=100) + unrelated (359, score=0), deduplicated.
 Each fold is stratified on source type (original/identical/unrelated).
-Swap skips identical pairs. Back-translation done once on GPU, reused across folds.
+Swap skips identical pairs. Back-translation applied on train split only per fold
+to prevent data leakage (slower but correct).
 """
 from __future__ import annotations
 
@@ -241,11 +242,26 @@ def main() -> None:
     holdout_unrelated = holdout_unrelated.add_column("source", ["unrelated"] * len(holdout_unrelated))
 
     full_dataset = concatenate_datasets([meaning_pool, holdout_identical, holdout_unrelated])
-    print(f"  Full corpus: {len(full_dataset)} examples")
+
+    # Deduplicate on (original, simplification) to prevent cross-split leakage
+    seen: set[str] = set()
+    unique_indices: list[int] = []
+    for i, (o, s) in enumerate(zip(full_dataset["original"], full_dataset["simplification"])):
+        key = f"{o}|||{s}"
+        if key not in seen:
+            seen.add(key)
+            unique_indices.append(i)
+    n_dupes = len(full_dataset) - len(unique_indices)
+    if n_dupes > 0:
+        print(f"  Removed {n_dupes} duplicate (original, simplification) pairs")
+    full_dataset = full_dataset.select(unique_indices)
+
+    print(f"  Full corpus: {len(full_dataset)} examples (after dedup)")
     print(f"    original: {len(meaning_pool)}, identical: {len(holdout_identical)}, unrelated: {len(holdout_unrelated)}")
 
-    # Back-translate the full corpus once (before splitting into folds)
-    bt_full_dataset: Dataset | None = None
+    # Load translation models once (reused across folds)
+    en_fr = None
+    fr_en = None
     if not args.skip_back_translation:
         print("\n=== Loading translation models ===")
         en_fr_tokenizer = MarianTokenizer.from_pretrained("Helsinki-NLP/opus-mt-en-fr")
@@ -254,15 +270,6 @@ def main() -> None:
         fr_en_model = MarianMTModel.from_pretrained("Helsinki-NLP/opus-mt-fr-en", torch_dtype=torch.bfloat16).to(device)
         en_fr = (en_fr_tokenizer, en_fr_model)
         fr_en = (fr_en_tokenizer, fr_en_model)
-
-        print("\n=== Back-translating full corpus (done once, reused across folds) ===")
-        bt_full_dataset = back_translate_dataset(full_dataset, en_fr, fr_en, device, args.batch_size)
-        print(f"  Back-translated corpus: {len(bt_full_dataset)} examples")
-
-        # Free GPU memory
-        del en_fr_model, fr_en_model
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
     else:
         print("\n=== Skipping back-translation ===")
 
@@ -288,16 +295,18 @@ def main() -> None:
         swap_path = os.path.join(fold_dir, "meaning_with_swap")
         swap_splits.save_to_disk(swap_path)
 
-        # 3. Back-translation - stratified split of the pre-computed bt corpus, then swap on train
-        if bt_full_dataset is not None:
-            bt_splits = create_fold_splits(bt_full_dataset, seed, stratify_column="source")
-            bt_swap_splits = DatasetDict({
-                "train": apply_commutative_swap(bt_splits["train"]),
-                "dev": bt_splits["dev"],
-                "test": bt_splits["test"],
+        # 3. Back-translation on TRAIN ONLY, then swap. Dev/test stay clean.
+        if en_fr is not None and fr_en is not None:
+            print(f"\n  Back-translating fold {fold_idx} train ({len(base_splits['train'])} examples)...")
+            bt_train = back_translate_dataset(base_splits["train"], en_fr, fr_en, device, args.batch_size)
+            bt_train_swapped = apply_commutative_swap(bt_train)
+            bt_splits = DatasetDict({
+                "train": bt_train_swapped,
+                "dev": base_splits["dev"],
+                "test": base_splits["test"],
             })
             bt_path = os.path.join(fold_dir, "meaning_with_back_translation")
-            bt_swap_splits.save_to_disk(bt_path)
+            bt_splits.save_to_disk(bt_path)
 
         # Stats
         source_counts: dict[str, int] = {}
@@ -307,6 +316,12 @@ def main() -> None:
               f"train={len(base_splits['train'])} {source_counts}, "
               f"dev={len(base_splits['dev'])}, "
               f"test={len(base_splits['test'])}")
+
+    # Free GPU memory
+    if en_fr is not None:
+        del en_fr, fr_en
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     print("\n=== Done ===")
     print(f"All datasets saved to {output_dir}/")

--- a/src/training/sweep_checkpoints.sh
+++ b/src/training/sweep_checkpoints.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Full sweep on a single GPU (use sweep_gpu{0,1,2}.sh for multi-GPU).
+# 14 models x 10 seeds = 140 runs
+# Reads pre-generated datasets from ./data (run prepare_datasets.py first)
+export WANDB_PROJECT="meaningbert-checkpoint-sweep"
+
+SEEDS=(42 43 44 45 46 47 48 49 50 51)
+COMMON="--data_dir=./data --data_augmentation=swap --gradient_accumulation_steps=2 --early_stopping_patience=50"
+
+declare -A CHECKPOINTS
+# checkpoint -> "learning_rate freeze_layers"
+CHECKPOINTS=(
+    ["bert-base-uncased"]="5e-5 0"
+    ["microsoft/deberta-v3-small"]="2e-5 0"
+    ["microsoft/deberta-v3-base"]="2e-5 0"
+    ["microsoft/deberta-v3-large"]="2e-5 6"
+    ["microsoft/deberta-v2-xlarge"]="1e-5 12"
+    ["google/electra-large-discriminator"]="3e-5 6"
+    ["answerdotai/ModernBERT-large"]="5e-5 6"
+    ["openai-community/gpt2"]="2e-5 0"
+    ["HuggingFaceTB/SmolLM2-135M"]="2e-5 0"
+    ["HuggingFaceTB/SmolLM2-360M"]="2e-5 0"
+    ["Qwen/Qwen2.5-0.5B"]="1e-5 0"
+    ["Qwen/Qwen2.5-1.5B"]="1e-5 8"
+    ["google/gemma-2-2b"]="1e-5 10"
+    ["microsoft/phi-2"]="1e-5 10"
+)
+
+for checkpoint in "${!CHECKPOINTS[@]}"; do
+    read -r lr freeze <<< "${CHECKPOINTS[$checkpoint]}"
+    for seed in "${SEEDS[@]}"; do
+        echo "=== Training checkpoint=${checkpoint} seed=${seed} lr=${lr} freeze=${freeze} ==="
+        python few_shot_training.py --seed="${seed}" --checkpoint="${checkpoint}" \
+            --learning_rate="${lr}" --freeze_layers="${freeze}" ${COMMON}
+    done
+done

--- a/src/training/sweep_checkpoints.sh
+++ b/src/training/sweep_checkpoints.sh
@@ -1,36 +1,49 @@
 #!/bin/bash
 # Full sweep on a single GPU (use sweep_gpu{0,1,2}.sh for multi-GPU).
-# 14 models x 10 seeds = 140 runs
+# 14 models x 10 folds x 2 augmentations = 280 runs
 # Reads pre-generated datasets from ./data (run prepare_datasets.py first)
 export WANDB_PROJECT="meaningbert-checkpoint-sweep"
 
+FOLDS=(0 1 2 3 4 5 6 7 8 9)
 SEEDS=(42 43 44 45 46 47 48 49 50 51)
-COMMON="--data_dir=./data --data_augmentation=swap --gradient_accumulation_steps=2 --early_stopping_patience=50"
+AUGMENTATIONS=("swap" "back_translation")
+COMMON="--data_dir=./data --early_stopping_patience=50 --bf16 --dataloader_num_workers=4"
 
+TOTAL=280
+RUN=0
+
+# checkpoint -> "learning_rate freeze_layers batch_size"
 declare -A CHECKPOINTS
-# checkpoint -> "learning_rate freeze_layers"
 CHECKPOINTS=(
-    ["bert-base-uncased"]="5e-5 0"
-    ["microsoft/deberta-v3-small"]="2e-5 0"
-    ["microsoft/deberta-v3-base"]="2e-5 0"
-    ["microsoft/deberta-v3-large"]="2e-5 6"
-    ["microsoft/deberta-v2-xlarge"]="1e-5 12"
-    ["google/electra-large-discriminator"]="3e-5 6"
-    ["answerdotai/ModernBERT-large"]="5e-5 6"
-    ["openai-community/gpt2"]="2e-5 0"
-    ["HuggingFaceTB/SmolLM2-135M"]="2e-5 0"
-    ["HuggingFaceTB/SmolLM2-360M"]="2e-5 0"
-    ["Qwen/Qwen2.5-0.5B"]="1e-5 0"
-    ["Qwen/Qwen2.5-1.5B"]="1e-5 8"
-    ["google/gemma-2-2b"]="1e-5 10"
-    ["microsoft/phi-2"]="1e-5 10"
+    ["bert-base-uncased"]="5e-5 0 128"
+    ["microsoft/deberta-v3-small"]="2e-5 0 128"
+    ["microsoft/deberta-v3-base"]="2e-5 0 128"
+    ["microsoft/deberta-v3-large"]="2e-5 6 64"
+    ["microsoft/deberta-v2-xlarge"]="1e-5 12 32"
+    ["google/electra-large-discriminator"]="3e-5 6 64"
+    ["answerdotai/ModernBERT-large"]="5e-5 6 64"
+    ["openai-community/gpt2"]="2e-5 0 128"
+    ["HuggingFaceTB/SmolLM2-135M"]="2e-5 0 128"
+    ["HuggingFaceTB/SmolLM2-360M"]="2e-5 0 128"
+    ["Qwen/Qwen2.5-0.5B"]="1e-5 0 64"
+    ["Qwen/Qwen2.5-1.5B"]="1e-5 8 32"
+    ["google/gemma-2-2b"]="1e-5 10 16"
+    ["microsoft/phi-2"]="1e-5 10 16"
 )
 
 for checkpoint in "${!CHECKPOINTS[@]}"; do
-    read -r lr freeze <<< "${CHECKPOINTS[$checkpoint]}"
-    for seed in "${SEEDS[@]}"; do
-        echo "=== Training checkpoint=${checkpoint} seed=${seed} lr=${lr} freeze=${freeze} ==="
-        python few_shot_training.py --seed="${seed}" --checkpoint="${checkpoint}" \
-            --learning_rate="${lr}" --freeze_layers="${freeze}" ${COMMON}
+    read -r lr freeze bs <<< "${CHECKPOINTS[$checkpoint]}"
+    for aug in "${AUGMENTATIONS[@]}"; do
+        for i in "${!FOLDS[@]}"; do
+            fold=${FOLDS[$i]}
+            seed=${SEEDS[$i]}
+            RUN=$((RUN + 1))
+            echo "=== [${RUN}/${TOTAL}] ${checkpoint} fold=${fold} aug=${aug} ==="
+            python few_shot_training.py --seed="${seed}" --fold="${fold}" \
+                --checkpoint="${checkpoint}" --learning_rate="${lr}" \
+                --freeze_layers="${freeze}" --per_device_train_batch_size="${bs}" \
+                --data_augmentation="${aug}" ${COMMON}
+        done
     done
 done
+echo "=== Done: ${TOTAL}/${TOTAL} runs ==="

--- a/src/training/sweep_gpu0.sh
+++ b/src/training/sweep_gpu0.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
-# GPU 0 - 5 models x 10 seeds = 50 runs
+# GPU 0 - 5 models x 10 folds x 2 augmentations = 100 runs
 # Reads pre-generated datasets from ./data (run prepare_datasets.py first)
 export CUDA_VISIBLE_DEVICES=0
 export WANDB_PROJECT="meaningbert-checkpoint-sweep"
 
+FOLDS=(0 1 2 3 4 5 6 7 8 9)
 SEEDS=(42 43 44 45 46 47 48 49 50 51)
-COMMON="--data_dir=./data --data_augmentation=swap --gradient_accumulation_steps=2 --early_stopping_patience=50"
+AUGMENTATIONS=("swap" "back_translation")
+COMMON="--data_dir=./data --gradient_accumulation_steps=2 --early_stopping_patience=50"
 
-TOTAL=50
+TOTAL=100
 RUN=0
 
 declare -A MODELS
@@ -21,11 +23,16 @@ MODELS=(
 
 for checkpoint in "${!MODELS[@]}"; do
     read -r lr freeze <<< "${MODELS[$checkpoint]}"
-    for seed in "${SEEDS[@]}"; do
-        RUN=$((RUN + 1))
-        echo "=== [GPU 0] [${RUN}/${TOTAL}] ${checkpoint} seed=${seed} lr=${lr} ==="
-        python few_shot_training.py --seed="${seed}" --checkpoint="${checkpoint}" \
-            --learning_rate="${lr}" --freeze_layers="${freeze}" ${COMMON}
+    for aug in "${AUGMENTATIONS[@]}"; do
+        for i in "${!FOLDS[@]}"; do
+            fold=${FOLDS[$i]}
+            seed=${SEEDS[$i]}
+            RUN=$((RUN + 1))
+            echo "=== [GPU 0] [${RUN}/${TOTAL}] ${checkpoint} fold=${fold} aug=${aug} ==="
+            python few_shot_training.py --seed="${seed}" --fold="${fold}" \
+                --checkpoint="${checkpoint}" --learning_rate="${lr}" \
+                --freeze_layers="${freeze}" --data_augmentation="${aug}" ${COMMON}
+        done
     done
 done
 echo "=== [GPU 0] Done: ${TOTAL}/${TOTAL} runs ==="

--- a/src/training/sweep_gpu0.sh
+++ b/src/training/sweep_gpu0.sh
@@ -1,28 +1,29 @@
 #!/bin/bash
 # GPU 0 - 5 models x 10 folds x 2 augmentations = 100 runs
-# Reads pre-generated datasets from ./data (run prepare_datasets.py first)
+# RTX 6000 Ada 49GB - bf16, batch_size=128 for small models
 export CUDA_VISIBLE_DEVICES=0
 export WANDB_PROJECT="meaningbert-checkpoint-sweep"
 
 FOLDS=(0 1 2 3 4 5 6 7 8 9)
 SEEDS=(42 43 44 45 46 47 48 49 50 51)
 AUGMENTATIONS=("swap" "back_translation")
-COMMON="--data_dir=./data --gradient_accumulation_steps=2 --early_stopping_patience=50"
+COMMON="--data_dir=./data --early_stopping_patience=50 --bf16 --dataloader_num_workers=4"
 
 TOTAL=100
 RUN=0
 
+# checkpoint -> "learning_rate freeze_layers batch_size"
 declare -A MODELS
 MODELS=(
-    ["bert-base-uncased"]="5e-5 0"
-    ["microsoft/deberta-v3-small"]="2e-5 0"
-    ["openai-community/gpt2"]="2e-5 0"
-    ["HuggingFaceTB/SmolLM2-135M"]="2e-5 0"
-    ["HuggingFaceTB/SmolLM2-360M"]="2e-5 0"
+    ["bert-base-uncased"]="5e-5 0 128"
+    ["microsoft/deberta-v3-small"]="2e-5 0 128"
+    ["openai-community/gpt2"]="2e-5 0 128"
+    ["HuggingFaceTB/SmolLM2-135M"]="2e-5 0 128"
+    ["HuggingFaceTB/SmolLM2-360M"]="2e-5 0 128"
 )
 
 for checkpoint in "${!MODELS[@]}"; do
-    read -r lr freeze <<< "${MODELS[$checkpoint]}"
+    read -r lr freeze bs <<< "${MODELS[$checkpoint]}"
     for aug in "${AUGMENTATIONS[@]}"; do
         for i in "${!FOLDS[@]}"; do
             fold=${FOLDS[$i]}
@@ -31,7 +32,8 @@ for checkpoint in "${!MODELS[@]}"; do
             echo "=== [GPU 0] [${RUN}/${TOTAL}] ${checkpoint} fold=${fold} aug=${aug} ==="
             python few_shot_training.py --seed="${seed}" --fold="${fold}" \
                 --checkpoint="${checkpoint}" --learning_rate="${lr}" \
-                --freeze_layers="${freeze}" --data_augmentation="${aug}" ${COMMON}
+                --freeze_layers="${freeze}" --per_device_train_batch_size="${bs}" \
+                --data_augmentation="${aug}" ${COMMON}
         done
     done
 done

--- a/src/training/sweep_gpu0.sh
+++ b/src/training/sweep_gpu0.sh
@@ -7,32 +7,25 @@ export WANDB_PROJECT="meaningbert-checkpoint-sweep"
 SEEDS=(42 43 44 45 46 47 48 49 50 51)
 COMMON="--data_dir=./data --data_augmentation=swap --gradient_accumulation_steps=2 --early_stopping_patience=50"
 
-# bert-base-uncased (110M, encoder)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 0] bert-base-uncased seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="bert-base-uncased" --learning_rate=5e-5 ${COMMON}
-done
+TOTAL=50
+RUN=0
 
-# deberta-v3-small (44M, encoder)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 0] deberta-v3-small seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="microsoft/deberta-v3-small" --learning_rate=2e-5 ${COMMON}
-done
+declare -A MODELS
+MODELS=(
+    ["bert-base-uncased"]="5e-5 0"
+    ["microsoft/deberta-v3-small"]="2e-5 0"
+    ["openai-community/gpt2"]="2e-5 0"
+    ["HuggingFaceTB/SmolLM2-135M"]="2e-5 0"
+    ["HuggingFaceTB/SmolLM2-360M"]="2e-5 0"
+)
 
-# gpt2 (124M, decoder)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 0] gpt2 seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="openai-community/gpt2" --learning_rate=2e-5 ${COMMON}
+for checkpoint in "${!MODELS[@]}"; do
+    read -r lr freeze <<< "${MODELS[$checkpoint]}"
+    for seed in "${SEEDS[@]}"; do
+        RUN=$((RUN + 1))
+        echo "=== [GPU 0] [${RUN}/${TOTAL}] ${checkpoint} seed=${seed} lr=${lr} ==="
+        python few_shot_training.py --seed="${seed}" --checkpoint="${checkpoint}" \
+            --learning_rate="${lr}" --freeze_layers="${freeze}" ${COMMON}
+    done
 done
-
-# SmolLM2-135M (135M, decoder)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 0] SmolLM2-135M seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="HuggingFaceTB/SmolLM2-135M" --learning_rate=2e-5 ${COMMON}
-done
-
-# SmolLM2-360M (360M, decoder)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 0] SmolLM2-360M seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="HuggingFaceTB/SmolLM2-360M" --learning_rate=2e-5 ${COMMON}
-done
+echo "=== [GPU 0] Done: ${TOTAL}/${TOTAL} runs ==="

--- a/src/training/sweep_gpu0.sh
+++ b/src/training/sweep_gpu0.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# GPU 0 - 5 models x 10 seeds = 50 runs
+# Reads pre-generated datasets from ./data (run prepare_datasets.py first)
+export CUDA_VISIBLE_DEVICES=0
+export WANDB_PROJECT="meaningbert-checkpoint-sweep"
+
+SEEDS=(42 43 44 45 46 47 48 49 50 51)
+COMMON="--data_dir=./data --data_augmentation=swap --gradient_accumulation_steps=2 --early_stopping_patience=50"
+
+# bert-base-uncased (110M, encoder)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 0] bert-base-uncased seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="bert-base-uncased" --learning_rate=5e-5 ${COMMON}
+done
+
+# deberta-v3-small (44M, encoder)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 0] deberta-v3-small seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="microsoft/deberta-v3-small" --learning_rate=2e-5 ${COMMON}
+done
+
+# gpt2 (124M, decoder)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 0] gpt2 seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="openai-community/gpt2" --learning_rate=2e-5 ${COMMON}
+done
+
+# SmolLM2-135M (135M, decoder)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 0] SmolLM2-135M seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="HuggingFaceTB/SmolLM2-135M" --learning_rate=2e-5 ${COMMON}
+done
+
+# SmolLM2-360M (360M, decoder)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 0] SmolLM2-360M seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="HuggingFaceTB/SmolLM2-360M" --learning_rate=2e-5 ${COMMON}
+done

--- a/src/training/sweep_gpu1.sh
+++ b/src/training/sweep_gpu1.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# GPU 1 - 5 models x 10 seeds = 50 runs
+# Reads pre-generated datasets from ./data (run prepare_datasets.py first)
+export CUDA_VISIBLE_DEVICES=1
+export WANDB_PROJECT="meaningbert-checkpoint-sweep"
+
+SEEDS=(42 43 44 45 46 47 48 49 50 51)
+COMMON="--data_dir=./data --data_augmentation=swap --gradient_accumulation_steps=2 --early_stopping_patience=50"
+
+# deberta-v3-base (86M, encoder)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 1] deberta-v3-base seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="microsoft/deberta-v3-base" --learning_rate=2e-5 ${COMMON}
+done
+
+# deberta-v3-large (304M, encoder, freeze 6 layers)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 1] deberta-v3-large seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="microsoft/deberta-v3-large" --learning_rate=2e-5 --freeze_layers=6 ${COMMON}
+done
+
+# electra-large (335M, encoder, freeze 6 layers)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 1] electra-large seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="google/electra-large-discriminator" --learning_rate=3e-5 --freeze_layers=6 ${COMMON}
+done
+
+# ModernBERT-large (395M, encoder, freeze 6 layers)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 1] ModernBERT-large seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="answerdotai/ModernBERT-large" --learning_rate=5e-5 --freeze_layers=6 ${COMMON}
+done
+
+# Qwen2.5-0.5B (500M, decoder)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 1] Qwen2.5-0.5B seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="Qwen/Qwen2.5-0.5B" --learning_rate=1e-5 ${COMMON}
+done

--- a/src/training/sweep_gpu1.sh
+++ b/src/training/sweep_gpu1.sh
@@ -1,28 +1,29 @@
 #!/bin/bash
 # GPU 1 - 5 models x 10 folds x 2 augmentations = 100 runs
-# Reads pre-generated datasets from ./data (run prepare_datasets.py first)
+# RTX 6000 Ada 49GB - bf16, batch_size adapted per model size
 export CUDA_VISIBLE_DEVICES=1
 export WANDB_PROJECT="meaningbert-checkpoint-sweep"
 
 FOLDS=(0 1 2 3 4 5 6 7 8 9)
 SEEDS=(42 43 44 45 46 47 48 49 50 51)
 AUGMENTATIONS=("swap" "back_translation")
-COMMON="--data_dir=./data --gradient_accumulation_steps=2 --early_stopping_patience=50"
+COMMON="--data_dir=./data --early_stopping_patience=50 --bf16 --dataloader_num_workers=4"
 
 TOTAL=100
 RUN=0
 
+# checkpoint -> "learning_rate freeze_layers batch_size"
 declare -A MODELS
 MODELS=(
-    ["microsoft/deberta-v3-base"]="2e-5 0"
-    ["microsoft/deberta-v3-large"]="2e-5 6"
-    ["google/electra-large-discriminator"]="3e-5 6"
-    ["answerdotai/ModernBERT-large"]="5e-5 6"
-    ["Qwen/Qwen2.5-0.5B"]="1e-5 0"
+    ["microsoft/deberta-v3-base"]="2e-5 0 128"
+    ["microsoft/deberta-v3-large"]="2e-5 6 64"
+    ["google/electra-large-discriminator"]="3e-5 6 64"
+    ["answerdotai/ModernBERT-large"]="5e-5 6 64"
+    ["Qwen/Qwen2.5-0.5B"]="1e-5 0 64"
 )
 
 for checkpoint in "${!MODELS[@]}"; do
-    read -r lr freeze <<< "${MODELS[$checkpoint]}"
+    read -r lr freeze bs <<< "${MODELS[$checkpoint]}"
     for aug in "${AUGMENTATIONS[@]}"; do
         for i in "${!FOLDS[@]}"; do
             fold=${FOLDS[$i]}
@@ -31,7 +32,8 @@ for checkpoint in "${!MODELS[@]}"; do
             echo "=== [GPU 1] [${RUN}/${TOTAL}] ${checkpoint} fold=${fold} aug=${aug} ==="
             python few_shot_training.py --seed="${seed}" --fold="${fold}" \
                 --checkpoint="${checkpoint}" --learning_rate="${lr}" \
-                --freeze_layers="${freeze}" --data_augmentation="${aug}" ${COMMON}
+                --freeze_layers="${freeze}" --per_device_train_batch_size="${bs}" \
+                --data_augmentation="${aug}" ${COMMON}
         done
     done
 done

--- a/src/training/sweep_gpu1.sh
+++ b/src/training/sweep_gpu1.sh
@@ -7,32 +7,25 @@ export WANDB_PROJECT="meaningbert-checkpoint-sweep"
 SEEDS=(42 43 44 45 46 47 48 49 50 51)
 COMMON="--data_dir=./data --data_augmentation=swap --gradient_accumulation_steps=2 --early_stopping_patience=50"
 
-# deberta-v3-base (86M, encoder)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 1] deberta-v3-base seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="microsoft/deberta-v3-base" --learning_rate=2e-5 ${COMMON}
-done
+TOTAL=50
+RUN=0
 
-# deberta-v3-large (304M, encoder, freeze 6 layers)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 1] deberta-v3-large seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="microsoft/deberta-v3-large" --learning_rate=2e-5 --freeze_layers=6 ${COMMON}
-done
+declare -A MODELS
+MODELS=(
+    ["microsoft/deberta-v3-base"]="2e-5 0"
+    ["microsoft/deberta-v3-large"]="2e-5 6"
+    ["google/electra-large-discriminator"]="3e-5 6"
+    ["answerdotai/ModernBERT-large"]="5e-5 6"
+    ["Qwen/Qwen2.5-0.5B"]="1e-5 0"
+)
 
-# electra-large (335M, encoder, freeze 6 layers)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 1] electra-large seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="google/electra-large-discriminator" --learning_rate=3e-5 --freeze_layers=6 ${COMMON}
+for checkpoint in "${!MODELS[@]}"; do
+    read -r lr freeze <<< "${MODELS[$checkpoint]}"
+    for seed in "${SEEDS[@]}"; do
+        RUN=$((RUN + 1))
+        echo "=== [GPU 1] [${RUN}/${TOTAL}] ${checkpoint} seed=${seed} lr=${lr} ==="
+        python few_shot_training.py --seed="${seed}" --checkpoint="${checkpoint}" \
+            --learning_rate="${lr}" --freeze_layers="${freeze}" ${COMMON}
+    done
 done
-
-# ModernBERT-large (395M, encoder, freeze 6 layers)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 1] ModernBERT-large seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="answerdotai/ModernBERT-large" --learning_rate=5e-5 --freeze_layers=6 ${COMMON}
-done
-
-# Qwen2.5-0.5B (500M, decoder)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 1] Qwen2.5-0.5B seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="Qwen/Qwen2.5-0.5B" --learning_rate=1e-5 ${COMMON}
-done
+echo "=== [GPU 1] Done: ${TOTAL}/${TOTAL} runs ==="

--- a/src/training/sweep_gpu1.sh
+++ b/src/training/sweep_gpu1.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
-# GPU 1 - 5 models x 10 seeds = 50 runs
+# GPU 1 - 5 models x 10 folds x 2 augmentations = 100 runs
 # Reads pre-generated datasets from ./data (run prepare_datasets.py first)
 export CUDA_VISIBLE_DEVICES=1
 export WANDB_PROJECT="meaningbert-checkpoint-sweep"
 
+FOLDS=(0 1 2 3 4 5 6 7 8 9)
 SEEDS=(42 43 44 45 46 47 48 49 50 51)
-COMMON="--data_dir=./data --data_augmentation=swap --gradient_accumulation_steps=2 --early_stopping_patience=50"
+AUGMENTATIONS=("swap" "back_translation")
+COMMON="--data_dir=./data --gradient_accumulation_steps=2 --early_stopping_patience=50"
 
-TOTAL=50
+TOTAL=100
 RUN=0
 
 declare -A MODELS
@@ -21,11 +23,16 @@ MODELS=(
 
 for checkpoint in "${!MODELS[@]}"; do
     read -r lr freeze <<< "${MODELS[$checkpoint]}"
-    for seed in "${SEEDS[@]}"; do
-        RUN=$((RUN + 1))
-        echo "=== [GPU 1] [${RUN}/${TOTAL}] ${checkpoint} seed=${seed} lr=${lr} ==="
-        python few_shot_training.py --seed="${seed}" --checkpoint="${checkpoint}" \
-            --learning_rate="${lr}" --freeze_layers="${freeze}" ${COMMON}
+    for aug in "${AUGMENTATIONS[@]}"; do
+        for i in "${!FOLDS[@]}"; do
+            fold=${FOLDS[$i]}
+            seed=${SEEDS[$i]}
+            RUN=$((RUN + 1))
+            echo "=== [GPU 1] [${RUN}/${TOTAL}] ${checkpoint} fold=${fold} aug=${aug} ==="
+            python few_shot_training.py --seed="${seed}" --fold="${fold}" \
+                --checkpoint="${checkpoint}" --learning_rate="${lr}" \
+                --freeze_layers="${freeze}" --data_augmentation="${aug}" ${COMMON}
+        done
     done
 done
 echo "=== [GPU 1] Done: ${TOTAL}/${TOTAL} runs ==="

--- a/src/training/sweep_gpu2.sh
+++ b/src/training/sweep_gpu2.sh
@@ -7,22 +7,28 @@ export WANDB_PROJECT="meaningbert-checkpoint-sweep"
 FOLDS=(0 1 2 3 4 5 6 7 8 9)
 SEEDS=(42 43 44 45 46 47 48 49 50 51)
 AUGMENTATIONS=("swap" "back_translation")
-COMMON="--data_dir=./data --early_stopping_patience=50 --bf16 --dataloader_num_workers=4"
-
 TOTAL=80
 RUN=0
 
-# checkpoint -> "learning_rate freeze_layers batch_size"
-declare -A MODELS
-MODELS=(
+# Models stable in bf16
+declare -A MODELS_BF16
+MODELS_BF16=(
     ["microsoft/deberta-v2-xlarge"]="1e-5 12 32"
     ["Qwen/Qwen2.5-1.5B"]="1e-5 8 32"
+)
+
+# Models that need fp32 (bf16 causes NaN gradients)
+declare -A MODELS_FP32
+MODELS_FP32=(
     ["google/gemma-2-2b"]="1e-5 10 4"
     ["microsoft/phi-2"]="1e-5 10 4"
 )
 
-for checkpoint in "${!MODELS[@]}"; do
-    read -r lr freeze bs <<< "${MODELS[$checkpoint]}"
+COMMON_BF16="--data_dir=./data --early_stopping_patience=50 --bf16 --dataloader_num_workers=4"
+COMMON_FP32="--data_dir=./data --early_stopping_patience=50 --no-bf16 --dataloader_num_workers=4"
+
+for checkpoint in "${!MODELS_BF16[@]}"; do
+    read -r lr freeze bs <<< "${MODELS_BF16[$checkpoint]}"
     for aug in "${AUGMENTATIONS[@]}"; do
         for i in "${!FOLDS[@]}"; do
             fold=${FOLDS[$i]}
@@ -32,7 +38,23 @@ for checkpoint in "${!MODELS[@]}"; do
             python few_shot_training.py --seed="${seed}" --fold="${fold}" \
                 --checkpoint="${checkpoint}" --learning_rate="${lr}" \
                 --freeze_layers="${freeze}" --per_device_train_batch_size="${bs}" \
-                --data_augmentation="${aug}" ${COMMON}
+                --data_augmentation="${aug}" ${COMMON_BF16}
+        done
+    done
+done
+
+for checkpoint in "${!MODELS_FP32[@]}"; do
+    read -r lr freeze bs <<< "${MODELS_FP32[$checkpoint]}"
+    for aug in "${AUGMENTATIONS[@]}"; do
+        for i in "${!FOLDS[@]}"; do
+            fold=${FOLDS[$i]}
+            seed=${SEEDS[$i]}
+            RUN=$((RUN + 1))
+            echo "=== [GPU 2] [${RUN}/${TOTAL}] ${checkpoint} fold=${fold} aug=${aug} (fp32) ==="
+            python few_shot_training.py --seed="${seed}" --fold="${fold}" \
+                --checkpoint="${checkpoint}" --learning_rate="${lr}" \
+                --freeze_layers="${freeze}" --per_device_train_batch_size="${bs}" \
+                --data_augmentation="${aug}" ${COMMON_FP32}
         done
     done
 done

--- a/src/training/sweep_gpu2.sh
+++ b/src/training/sweep_gpu2.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# GPU 2 - 4 models x 10 seeds = 40 runs
+# Large models with layer freezing
+# Reads pre-generated datasets from ./data (run prepare_datasets.py first)
+export CUDA_VISIBLE_DEVICES=2
+export WANDB_PROJECT="meaningbert-checkpoint-sweep"
+
+SEEDS=(42 43 44 45 46 47 48 49 50 51)
+COMMON="--data_dir=./data --data_augmentation=swap --gradient_accumulation_steps=2 --early_stopping_patience=50"
+
+# deberta-v2-xlarge (900M, encoder, freeze 12 layers)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 2] deberta-v2-xlarge seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="microsoft/deberta-v2-xlarge" --learning_rate=1e-5 --freeze_layers=12 ${COMMON}
+done
+
+# Qwen2.5-1.5B (1.5B, decoder, freeze 8 layers)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 2] Qwen2.5-1.5B seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="Qwen/Qwen2.5-1.5B" --learning_rate=1e-5 --freeze_layers=8 ${COMMON}
+done
+
+# gemma-2-2b (2.6B, decoder, freeze 10 layers)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 2] gemma-2-2b seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="google/gemma-2-2b" --learning_rate=1e-5 --freeze_layers=10 ${COMMON}
+done
+
+# phi-2 (2.7B, decoder, freeze 10 layers)
+for seed in "${SEEDS[@]}"; do
+    echo "=== [GPU 2] phi-2 seed=${seed} ==="
+    python few_shot_training.py --seed="${seed}" --checkpoint="microsoft/phi-2" --learning_rate=1e-5 --freeze_layers=10 ${COMMON}
+done

--- a/src/training/sweep_gpu2.sh
+++ b/src/training/sweep_gpu2.sh
@@ -17,8 +17,8 @@ declare -A MODELS
 MODELS=(
     ["microsoft/deberta-v2-xlarge"]="1e-5 12 32"
     ["Qwen/Qwen2.5-1.5B"]="1e-5 8 32"
-    ["google/gemma-2-2b"]="1e-5 10 16"
-    ["microsoft/phi-2"]="1e-5 10 16"
+    ["google/gemma-2-2b"]="1e-5 10 4"
+    ["microsoft/phi-2"]="1e-5 10 4"
 )
 
 for checkpoint in "${!MODELS[@]}"; do

--- a/src/training/sweep_gpu2.sh
+++ b/src/training/sweep_gpu2.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
-# GPU 2 - 4 models x 10 seeds = 40 runs
+# GPU 2 - 4 models x 10 folds x 2 augmentations = 80 runs
 # Large models with layer freezing
 # Reads pre-generated datasets from ./data (run prepare_datasets.py first)
 export CUDA_VISIBLE_DEVICES=2
 export WANDB_PROJECT="meaningbert-checkpoint-sweep"
 
+FOLDS=(0 1 2 3 4 5 6 7 8 9)
 SEEDS=(42 43 44 45 46 47 48 49 50 51)
-COMMON="--data_dir=./data --data_augmentation=swap --gradient_accumulation_steps=2 --early_stopping_patience=50"
+AUGMENTATIONS=("swap" "back_translation")
+COMMON="--data_dir=./data --gradient_accumulation_steps=2 --early_stopping_patience=50"
 
-TOTAL=40
+TOTAL=80
 RUN=0
 
 declare -A MODELS
@@ -21,11 +23,16 @@ MODELS=(
 
 for checkpoint in "${!MODELS[@]}"; do
     read -r lr freeze <<< "${MODELS[$checkpoint]}"
-    for seed in "${SEEDS[@]}"; do
-        RUN=$((RUN + 1))
-        echo "=== [GPU 2] [${RUN}/${TOTAL}] ${checkpoint} seed=${seed} lr=${lr} ==="
-        python few_shot_training.py --seed="${seed}" --checkpoint="${checkpoint}" \
-            --learning_rate="${lr}" --freeze_layers="${freeze}" ${COMMON}
+    for aug in "${AUGMENTATIONS[@]}"; do
+        for i in "${!FOLDS[@]}"; do
+            fold=${FOLDS[$i]}
+            seed=${SEEDS[$i]}
+            RUN=$((RUN + 1))
+            echo "=== [GPU 2] [${RUN}/${TOTAL}] ${checkpoint} fold=${fold} aug=${aug} ==="
+            python few_shot_training.py --seed="${seed}" --fold="${fold}" \
+                --checkpoint="${checkpoint}" --learning_rate="${lr}" \
+                --freeze_layers="${freeze}" --data_augmentation="${aug}" ${COMMON}
+        done
     done
 done
 echo "=== [GPU 2] Done: ${TOTAL}/${TOTAL} runs ==="

--- a/src/training/sweep_gpu2.sh
+++ b/src/training/sweep_gpu2.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 # GPU 2 - 4 models x 10 folds x 2 augmentations = 80 runs
-# Large models with layer freezing
-# Reads pre-generated datasets from ./data (run prepare_datasets.py first)
+# RTX 6000 Ada 49GB - bf16, large models with layer freezing
 export CUDA_VISIBLE_DEVICES=2
 export WANDB_PROJECT="meaningbert-checkpoint-sweep"
 
 FOLDS=(0 1 2 3 4 5 6 7 8 9)
 SEEDS=(42 43 44 45 46 47 48 49 50 51)
 AUGMENTATIONS=("swap" "back_translation")
-COMMON="--data_dir=./data --gradient_accumulation_steps=2 --early_stopping_patience=50"
+COMMON="--data_dir=./data --early_stopping_patience=50 --bf16 --dataloader_num_workers=4"
 
 TOTAL=80
 RUN=0
 
+# checkpoint -> "learning_rate freeze_layers batch_size"
 declare -A MODELS
 MODELS=(
-    ["microsoft/deberta-v2-xlarge"]="1e-5 12"
-    ["Qwen/Qwen2.5-1.5B"]="1e-5 8"
-    ["google/gemma-2-2b"]="1e-5 10"
-    ["microsoft/phi-2"]="1e-5 10"
+    ["microsoft/deberta-v2-xlarge"]="1e-5 12 32"
+    ["Qwen/Qwen2.5-1.5B"]="1e-5 8 32"
+    ["google/gemma-2-2b"]="1e-5 10 16"
+    ["microsoft/phi-2"]="1e-5 10 16"
 )
 
 for checkpoint in "${!MODELS[@]}"; do
-    read -r lr freeze <<< "${MODELS[$checkpoint]}"
+    read -r lr freeze bs <<< "${MODELS[$checkpoint]}"
     for aug in "${AUGMENTATIONS[@]}"; do
         for i in "${!FOLDS[@]}"; do
             fold=${FOLDS[$i]}
@@ -31,7 +31,8 @@ for checkpoint in "${!MODELS[@]}"; do
             echo "=== [GPU 2] [${RUN}/${TOTAL}] ${checkpoint} fold=${fold} aug=${aug} ==="
             python few_shot_training.py --seed="${seed}" --fold="${fold}" \
                 --checkpoint="${checkpoint}" --learning_rate="${lr}" \
-                --freeze_layers="${freeze}" --data_augmentation="${aug}" ${COMMON}
+                --freeze_layers="${freeze}" --per_device_train_batch_size="${bs}" \
+                --data_augmentation="${aug}" ${COMMON}
         done
     done
 done

--- a/src/training/sweep_gpu2.sh
+++ b/src/training/sweep_gpu2.sh
@@ -8,26 +8,24 @@ export WANDB_PROJECT="meaningbert-checkpoint-sweep"
 SEEDS=(42 43 44 45 46 47 48 49 50 51)
 COMMON="--data_dir=./data --data_augmentation=swap --gradient_accumulation_steps=2 --early_stopping_patience=50"
 
-# deberta-v2-xlarge (900M, encoder, freeze 12 layers)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 2] deberta-v2-xlarge seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="microsoft/deberta-v2-xlarge" --learning_rate=1e-5 --freeze_layers=12 ${COMMON}
-done
+TOTAL=40
+RUN=0
 
-# Qwen2.5-1.5B (1.5B, decoder, freeze 8 layers)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 2] Qwen2.5-1.5B seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="Qwen/Qwen2.5-1.5B" --learning_rate=1e-5 --freeze_layers=8 ${COMMON}
-done
+declare -A MODELS
+MODELS=(
+    ["microsoft/deberta-v2-xlarge"]="1e-5 12"
+    ["Qwen/Qwen2.5-1.5B"]="1e-5 8"
+    ["google/gemma-2-2b"]="1e-5 10"
+    ["microsoft/phi-2"]="1e-5 10"
+)
 
-# gemma-2-2b (2.6B, decoder, freeze 10 layers)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 2] gemma-2-2b seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="google/gemma-2-2b" --learning_rate=1e-5 --freeze_layers=10 ${COMMON}
+for checkpoint in "${!MODELS[@]}"; do
+    read -r lr freeze <<< "${MODELS[$checkpoint]}"
+    for seed in "${SEEDS[@]}"; do
+        RUN=$((RUN + 1))
+        echo "=== [GPU 2] [${RUN}/${TOTAL}] ${checkpoint} seed=${seed} lr=${lr} ==="
+        python few_shot_training.py --seed="${seed}" --checkpoint="${checkpoint}" \
+            --learning_rate="${lr}" --freeze_layers="${freeze}" ${COMMON}
+    done
 done
-
-# phi-2 (2.7B, decoder, freeze 10 layers)
-for seed in "${SEEDS[@]}"; do
-    echo "=== [GPU 2] phi-2 seed=${seed} ==="
-    python few_shot_training.py --seed="${seed}" --checkpoint="microsoft/phi-2" --learning_rate=1e-5 --freeze_layers=10 ${COMMON}
-done
+echo "=== [GPU 2] Done: ${TOTAL}/${TOTAL} runs ==="

--- a/src/training/validate_datasets.py
+++ b/src/training/validate_datasets.py
@@ -1,0 +1,224 @@
+"""Validate pre-generated dataset folds for correctness.
+
+Run after prepare_datasets.py::
+
+    python validate_datasets.py --data_dir ./data
+
+Checks:
+    - All expected folds and variants exist
+    - No data leakage between train/dev/test splits
+    - Stratification: source types are proportionally distributed
+    - Label sanity: identical ~100, unrelated ~0, original in range
+    - Swap correctness: swapped pairs have reversed original/simplification
+    - Back-translation: corpus is larger than swap variant
+    - Column consistency across all datasets
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections import Counter
+
+from datasets import load_from_disk
+
+
+def check_exists(path: str, name: str) -> bool:
+    """Check that a dataset directory exists."""
+    if not os.path.isdir(path):
+        print(f"  FAIL: {name} not found at {path}")
+        return False
+    return True
+
+
+def check_no_leakage(splits: dict[str, set[str]], fold_name: str) -> bool:
+    """Check that there is no overlap between train/dev/test splits."""
+    ok = True
+    for a, b in [("train", "dev"), ("train", "test"), ("dev", "test")]:
+        if a not in splits or b not in splits:
+            continue
+        overlap = splits[a] & splits[b]
+        if overlap:
+            print(f"  FAIL [{fold_name}]: {len(overlap)} leaked examples between {a} and {b}")
+            ok = False
+    return ok
+
+
+def make_fingerprints(dataset) -> set[str]:
+    """Create a set of fingerprints from (original, simplification) pairs."""
+    return {f"{o}|||{s}" for o, s in zip(dataset["original"], dataset["simplification"])}
+
+
+def check_stratification(dataset, split_name: str, fold_name: str, expected_sources: set[str]) -> bool:
+    """Check that all expected source types are present in the split."""
+    if "source" not in dataset.column_names:
+        print(f"  FAIL [{fold_name}/{split_name}]: missing 'source' column")
+        return False
+    sources = set(dataset["source"])
+    missing = expected_sources - sources
+    if missing:
+        print(f"  FAIL [{fold_name}/{split_name}]: missing source types: {missing}")
+        return False
+    return True
+
+
+def check_labels(dataset, split_name: str, fold_name: str) -> bool:
+    """Check label sanity per source type."""
+    ok = True
+    if "source" not in dataset.column_names:
+        return True
+
+    for i, (label, source) in enumerate(zip(dataset["label"], dataset["source"])):
+        if source == "identical" and label < 90:
+            print(f"  FAIL [{fold_name}/{split_name}]: identical pair at idx {i} has label={label} (expected ~100)")
+            ok = False
+            break
+        if source == "unrelated" and label > 10:
+            print(f"  FAIL [{fold_name}/{split_name}]: unrelated pair at idx {i} has label={label} (expected ~0)")
+            ok = False
+            break
+    return ok
+
+
+def check_swap_present(swap_dataset, base_dataset, split_name: str, fold_name: str) -> bool:
+    """Check that swap variant has more training examples than base (swap applied on train only)."""
+    if split_name != "train":
+        return True
+    if len(swap_dataset) <= len(base_dataset):
+        print(f"  FAIL [{fold_name}/{split_name}]: swap ({len(swap_dataset)}) should be larger than base ({len(base_dataset)})")
+        return False
+    return True
+
+
+def main() -> None:
+    """Validate all dataset folds."""
+    parser = argparse.ArgumentParser(description="Validate pre-generated dataset folds.")
+    parser.add_argument("--data_dir", type=str, default="./data", help="Root data directory.")
+    parser.add_argument("--num_folds", type=int, default=10, help="Expected number of folds.")
+    args = parser.parse_args()
+
+    data_dir: str = args.data_dir
+    num_folds: int = args.num_folds
+    errors = 0
+    checks = 0
+
+    print(f"Validating datasets in {data_dir}/\n")
+
+    # Check folds directory
+    folds_dir = os.path.join(data_dir, "folds")
+    if not check_exists(folds_dir, "folds/"):
+        print("\nABORT: folds directory missing.")
+        sys.exit(1)
+
+    variants = ["meaning", "meaning_with_swap", "meaning_with_back_translation"]
+    base_sources = {"original", "identical", "unrelated"}
+    splits = ["train", "dev", "test"]
+
+    for fold_idx in range(num_folds):
+        fold_name = f"fold_{fold_idx}"
+        fold_dir = os.path.join(folds_dir, fold_name)
+        print(f"--- {fold_name} ---")
+
+        if not check_exists(fold_dir, fold_name):
+            errors += 1
+            continue
+
+        datasets: dict[str, dict] = {}
+        for variant in variants:
+            variant_path = os.path.join(fold_dir, variant)
+            checks += 1
+            if not check_exists(variant_path, f"{fold_name}/{variant}"):
+                errors += 1
+                continue
+            datasets[variant] = load_from_disk(variant_path)
+
+        if not datasets:
+            continue
+
+        # Check each variant
+        for variant, ds in datasets.items():
+            # Column check
+            checks += 1
+            expected_cols = {"original", "simplification", "label"}
+            for split_name in splits:
+                if split_name not in ds:
+                    print(f"  FAIL [{fold_name}/{variant}]: missing split '{split_name}'")
+                    errors += 1
+                    continue
+                actual_cols = set(ds[split_name].column_names)
+                missing_cols = expected_cols - actual_cols
+                if missing_cols:
+                    print(f"  FAIL [{fold_name}/{variant}/{split_name}]: missing columns {missing_cols}")
+                    errors += 1
+
+            # No leakage (using base meaning variant fingerprints)
+            checks += 1
+            fingerprints = {}
+            for split_name in splits:
+                if split_name in ds:
+                    fingerprints[split_name] = make_fingerprints(ds[split_name])
+            if not check_no_leakage(fingerprints, f"{fold_name}/{variant}"):
+                errors += 1
+
+            # Per-split checks
+            for split_name in splits:
+                if split_name not in ds:
+                    continue
+
+                # Stratification (base sources must be present in base variant)
+                if variant == "meaning":
+                    checks += 1
+                    if not check_stratification(ds[split_name], split_name, f"{fold_name}/{variant}", base_sources):
+                        errors += 1
+
+                # Label sanity
+                checks += 1
+                if not check_labels(ds[split_name], split_name, f"{fold_name}/{variant}"):
+                    errors += 1
+
+            # Swap should have more train examples than base
+            if "meaning" in datasets and "meaning_with_swap" in datasets:
+                checks += 1
+                if not check_swap_present(
+                    datasets["meaning_with_swap"]["train"],
+                    datasets["meaning"]["train"],
+                    "train",
+                    fold_name,
+                ):
+                    errors += 1
+
+            # Back-translation should have more train examples than swap
+            if "meaning_with_swap" in datasets and "meaning_with_back_translation" in datasets:
+                checks += 1
+                bt_train = len(datasets["meaning_with_back_translation"]["train"])
+                swap_train = len(datasets["meaning_with_swap"]["train"])
+                if bt_train <= swap_train:
+                    print(f"  FAIL [{fold_name}]: back_translation train ({bt_train}) should be larger than swap train ({swap_train})")
+                    errors += 1
+
+        # Print stats for this fold
+        if "meaning" in datasets:
+            base = datasets["meaning"]
+            print(f"  Base:    train={len(base['train'])}, dev={len(base['dev'])}, test={len(base['test'])}")
+            if "source" in base["train"].column_names:
+                counts = Counter(base["train"]["source"])
+                print(f"           train sources: {dict(counts)}")
+        if "meaning_with_swap" in datasets:
+            swap = datasets["meaning_with_swap"]
+            print(f"  Swap:    train={len(swap['train'])}, dev={len(swap['dev'])}, test={len(swap['test'])}")
+        if "meaning_with_back_translation" in datasets:
+            bt = datasets["meaning_with_back_translation"]
+            print(f"  BT+Swap: train={len(bt['train'])}, dev={len(bt['dev'])}, test={len(bt['test'])}")
+        print()
+
+    # Summary
+    print("=" * 50)
+    if errors == 0:
+        print(f"ALL PASSED: {checks} checks, 0 errors")
+    else:
+        print(f"FAILED: {errors} errors out of {checks} checks")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Refactor `few_shot_training.py` pour supporter 14 checkpoints (encoders + decoders) avec LR par famille, layer freezing, gradient accumulation, early stopping (patience=50)
- Ajout de `prepare_datasets.py` pour pre-generer les datasets sur disque (base, swap, back-translation) et eviter les telechargements repetitifs
- 3 scripts GPU (`sweep_gpu{0,1,2}.sh`) equilibres par charge de calcul, 10 seeds par modele
- Best model sauve comme artifact wandb avec metadata complete pour deploiement HF
- Script d'ensemble post-sweep (`ensemble_evaluate.py`)

## Modeles testes
| Type | Modeles |
|---|---|
| DeBERTa | v3-small, v3-base, v3-large, v2-xlarge |
| Autres encoders | ELECTRA-large, ModernBERT-large |
| Decoders | GPT-2, SmolLM2-135M, SmolLM2-360M, Qwen2.5-0.5B, Qwen2.5-1.5B, Gemma-2-2B, Phi-2 |
| Baseline | BERT-base-uncased |

## Workflow
```bash
python prepare_datasets.py --output_dir ./data
bash sweep_gpu0.sh & bash sweep_gpu1.sh & bash sweep_gpu2.sh &
```

## Test plan
- [ ] Valider `prepare_datasets.py` genere les 5 dossiers dans `./data`
- [ ] Tester un run single-model pour verifier wandb artifact upload
- [ ] Verifier le layer freezing sur un modele decoder (GPT-2) et encoder (DeBERTa)
- [ ] Confirmer early stopping coupe avant 500 epochs

🤖 Generated with [Claude Code](https://claude.com/claude-code)