### PR TITLE
Fix phi-2 precision, add rerun script for 100 failed runs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,45 @@
+---
+
+# MeaningBERT - Multi-checkpoint sweep - 2026-04-12
+
+## Contexte
+Sweep systematique de 14 modeles pretrained (encoders + decoders) pour le fine-tuning de MeaningBERT (regression de preservation du sens). Objectif : trouver un meilleur backbone que bert-base-uncased et mesurer l'impact du data augmentation (swap commutative + back-translation EN->FR->EN).
+
+## Ou en est-on
+- [x] Refactor few_shot_training.py : --checkpoint, --fold, --data_augmentation, --learning_rate, --freeze_layers, bf16, early stopping
+- [x] prepare_datasets.py : corpus merge (base+identical+unrelated=2042 dedup), k-fold stratifie, swap, back-translation GPU
+- [x] validate_datasets.py : 0 leakage confirme sur tous les folds
+- [x] 3 sweep scripts GPU (sweep_gpu0/1/2.sh) + launch_sweeps.sh
+- [x] Wandb artifact logging du best model par run
+- [x] cleanup.py pour nettoyer checkpoints + runs crashees
+- [x] Fix : eval_strategy, processing_class, metrics squeeze, fp32 pour phi-2/gemma
+- [ ] **Sweeps en cours** sur caribou (3x RTX 6000 Ada 49GB)
+- [ ] **Relancer les 100 runs echoues via `rerun_failed.sh`** (deberta-v3-small/base/large + deberta-v2-xlarge + phi-2). Script pret dans `src/training/rerun_failed.sh`. Lancer avec `nohup bash rerun_failed.sh > rerun.log 2>&1 &` depuis `src/training/`. 2 causes :
+  - 80 runs deberta-v2/v3 : nvrtc `libnvrtc-builtins.so.13.0` (installe 2026-04-14), bf16 ok
+  - 20 runs phi-2 : backward dtype mismatch en fp32, fix = fp16 (`--fp16` ajoute au parser)
+- [ ] Surveiller wandb : runs qui divergent, early stopping
+- [ ] Notebook d'analyse post-sweep (R2, Pearson par checkpoint/aug/fold)
+- [ ] Ensemble des meilleurs modeles
+- [ ] Deploiement HuggingFace du meilleur modele
+
+## Fichiers cles
+- `src/training/few_shot_training.py` - script d'entrainement principal (14 modeles supportes)
+- `src/training/prepare_datasets.py` - generation corpus (dedup, k-fold stratifie, swap, back-translation)
+- `src/training/validate_datasets.py` - validation zero-leakage des folds
+- `src/training/sweep_gpu0.sh` - GPU 0 : BERT, deberta-v3-small, gpt2, SmolLM2-135M, SmolLM2-360M
+- `src/training/sweep_gpu1.sh` - GPU 1 : deberta-v3-base/large, electra-large, ModernBERT-large, Qwen2.5-0.5B
+- `src/training/sweep_gpu2.sh` - GPU 2 : deberta-v2-xlarge, Qwen2.5-1.5B, gemma-2-2b (fp32), phi-2 (fp32)
+- `src/training/launch_sweeps.sh` - lance les 3 GPUs en parallele
+- `src/training/cleanup.py` - nettoyage checkpoints + wandb runs crashees
+- `src/training/ensemble_evaluate.py` - evaluation ensemble post-sweep
+- `src/training/metrics/metrics.py` - compute_metrics avec squeeze + nan_to_num
+
+## Notes pour reprendre
+- Serveur : caribou (dabea241), 3x RTX 6000 Ada 49GB, driver 595.58.03, CUDA 13.2, PyTorch cu126
+- Branche : `experiment/multi-checkpoint-sweep`, PR #5
+- Wandb projet : `davebulaval/meaningbert-checkpoint-sweep`
+- phi-2 et gemma-2-2b : fp32 obligatoire (bf16 cause NaN), batch_size=4
+- Qwen2.5-1.5B : 279 500 steps par run, surveiller early stopping
+- Le cleanup auto des checkpoints intermediaires est dans few_shot_training.py (shutil.rmtree apres artifact upload)
+- Les anciens sweep scripts (sweep_data_augmentation*.sh, sweep_no_data_augmentation.sh) sont obsoletes
+- requirements.txt : torch>=2.6.0, transformers>=4.40.0, sentencepiece ajoute

--- a/src/training/cleanup.py
+++ b/src/training/cleanup.py
@@ -11,14 +11,13 @@ Usage::
     # Also clean failed/crashed wandb runs
     python cleanup.py --delete --clean-wandb
 """
+
 from __future__ import annotations
 
 import argparse
 import os
 import shutil
-from glob import glob
 from pathlib import Path
-
 
 TRAINING_DIR = Path(__file__).parent
 
@@ -75,7 +74,7 @@ def format_size(size_bytes: int) -> str:
 def clean_wandb_failed(delete: bool) -> None:
     """Delete failed wandb runs via the API."""
     try:
-        import wandb
+        import wandb  # pylint: disable=import-outside-toplevel
     except ImportError:
         print("  wandb not installed, skipping API cleanup")
         return
@@ -84,7 +83,7 @@ def clean_wandb_failed(delete: bool) -> None:
     project = "davebulaval/meaningbert-checkpoint-sweep"
     try:
         runs = api.runs(project, filters={"state": "crashed"})
-    except Exception as e:
+    except wandb.errors.CommError as e:
         print(f"  Could not fetch wandb runs: {e}")
         return
 

--- a/src/training/ensemble_evaluate.py
+++ b/src/training/ensemble_evaluate.py
@@ -4,6 +4,7 @@ Usage::
 
     python ensemble_evaluate.py --model_dirs model_a/ model_b/ model_c/ --data_dir ./data --fold 0
 """
+
 from __future__ import annotations
 
 import argparse
@@ -28,13 +29,19 @@ def create_parser() -> argparse.ArgumentParser:
     """Build the CLI argument parser."""
     parser = argparse.ArgumentParser(description="Ensemble evaluation over multiple saved models.")
     parser.add_argument(
-        "--model_dirs", type=str, nargs="+", required=True,
+        "--model_dirs",
+        type=str,
+        nargs="+",
+        required=True,
         help="Paths to saved model directories.",
     )
     parser.add_argument("--data_dir", type=str, default=None, help="Root data directory (from prepare_datasets.py).")
     parser.add_argument("--fold", type=int, default=None, help="Fold index (0-9). Requires --data_dir.")
     parser.add_argument(
-        "--split", type=str, default="test", choices=["test", "dev"],
+        "--split",
+        type=str,
+        default="test",
+        choices=["test", "dev"],
         help="Dataset split to evaluate on.",
     )
     return parser
@@ -112,7 +119,7 @@ def main() -> None:
     print(f"  R2:      {r2:.4f}")
     print(f"  Pearson: {pearson_r:.4f} (p={pearson_p:.2e})")
 
-    print(f"\n  Per-model R2:")
+    print("\n  Per-model R2:")
     for model_dir, preds in zip(args.model_dirs, all_preds):
         model_r2 = r2_score(labels, preds)
         print(f"    {os.path.basename(model_dir)}: {model_r2:.4f}")

--- a/src/training/few_shot_training.py
+++ b/src/training/few_shot_training.py
@@ -1,4 +1,5 @@
 """Fine-tune a pretrained model for meaning preservation regression on CSMD."""
+
 from __future__ import annotations
 
 import argparse
@@ -76,11 +77,11 @@ def freeze_layers(model: PreTrainedModel, num_layers_to_freeze: int) -> None:
     # Locate the layer list depending on the model architecture.
     layer_list = None
     for attr_path in [
-        "base_model.encoder.layer",       # BERT, DeBERTa, ELECTRA
-        "deberta.encoder.layer",           # DeBERTa v2/v3
-        "model.layers",                    # LLaMA, Qwen, Gemma, Phi, SmolLM
-        "transformer.h",                   # GPT-2
-        "encoder.layers",                  # ModernBERT
+        "base_model.encoder.layer",  # BERT, DeBERTa, ELECTRA
+        "deberta.encoder.layer",  # DeBERTa v2/v3
+        "model.layers",  # LLaMA, Qwen, Gemma, Phi, SmolLM
+        "transformer.h",  # GPT-2
+        "encoder.layers",  # ModernBERT
     ]:
         obj = model
         found = True
@@ -111,39 +112,61 @@ def create_parser() -> argparse.ArgumentParser:
 
     parser.add_argument("--seed", type=int, default=45, help="Random seed for training.")
     parser.add_argument(
-        "--data_dir", type=str, default=None,
+        "--data_dir",
+        type=str,
+        default=None,
         help="Root directory containing pre-generated datasets (from prepare_datasets.py).",
     )
     parser.add_argument(
-        "--fold", type=int, default=None,
+        "--fold",
+        type=int,
+        default=None,
         help="Fold index for k-fold cross-validation (0-9). Requires --data_dir.",
     )
     parser.add_argument(
-        "--data_augmentation", type=str, default="swap",
+        "--data_augmentation",
+        type=str,
+        default="swap",
         choices=["none", "swap", "back_translation"],
         help="Data augmentation variant.",
     )
     parser.add_argument(
-        "--checkpoint", type=str, default="bert-base-uncased",
+        "--checkpoint",
+        type=str,
+        default="bert-base-uncased",
         help="Pretrained model checkpoint for fine-tuning.",
     )
     parser.add_argument(
-        "--learning_rate", type=float, default=None,
+        "--learning_rate",
+        type=float,
+        default=None,
         help="Learning rate. If not set, uses a per-model-family default.",
     )
     parser.add_argument("--freeze_layers", type=int, default=0, help="Number of bottom layers to freeze.")
     parser.add_argument("--per_device_train_batch_size", type=int, default=64, help="Training batch size per device.")
     parser.add_argument(
-        "--gradient_accumulation_steps", type=int, default=1,
+        "--gradient_accumulation_steps",
+        type=int,
+        default=1,
         help="Gradient accumulation steps (effective batch = batch_size * accumulation).",
     )
     parser.add_argument(
-        "--bf16", action=argparse.BooleanOptionalAction, default=True,
+        "--bf16",
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help="Use bfloat16 mixed precision (recommended for RTX Ada GPUs). Use --no-bf16 to disable.",
+    )
+    parser.add_argument(
+        "--fp16",
+        action="store_true",
+        default=False,
+        help="Use float16 mixed precision. For models where bf16 causes NaN and fp32 causes dtype errors.",
     )
     parser.add_argument("--dataloader_num_workers", type=int, default=4, help="Number of dataloader workers.")
     parser.add_argument(
-        "--early_stopping_patience", type=int, default=50,
+        "--early_stopping_patience",
+        type=int,
+        default=50,
         help="Early stopping patience in epochs. 0 to disable.",
     )
     return parser
@@ -164,6 +187,7 @@ def main() -> None:
     batch_size: int = args.per_device_train_batch_size
     grad_accum: int = args.gradient_accumulation_steps
     use_bf16: bool = args.bf16
+    use_fp16: bool = args.fp16
     num_workers: int = args.dataloader_num_workers
     es_patience: int = args.early_stopping_patience
 
@@ -184,12 +208,8 @@ def main() -> None:
             # Extract them from the test set by source tag for holdout evaluation.
             test_set = csmd_dataset["test"]
             if "source" in test_set.column_names:
-                holdout_identical_dataset = DatasetDict({
-                    "test": test_set.filter(lambda x: x["source"] == "identical")
-                })
-                holdout_unrelated_dataset = DatasetDict({
-                    "test": test_set.filter(lambda x: x["source"] == "unrelated")
-                })
+                holdout_identical_dataset = DatasetDict({"test": test_set.filter(lambda x: x["source"] == "identical")})
+                holdout_unrelated_dataset = DatasetDict({"test": test_set.filter(lambda x: x["source"] == "unrelated")})
         else:
             holdout_identical_dataset = load_from_disk(os.path.join(data_dir, "meaning_holdout_identical"))
             holdout_unrelated_dataset = load_from_disk(os.path.join(data_dir, "meaning_holdout_unrelated"))
@@ -215,7 +235,10 @@ def main() -> None:
     # Remove non-tensor columns before tokenization to avoid Trainer collation errors.
     cols_to_remove = [c for c in COLUMNS_TO_REMOVE if c in csmd_dataset["train"].column_names]
     tokenized_csmd_dataset = csmd_dataset.map(
-        tokenize_function, batched=True, remove_columns=cols_to_remove, num_proc=4,
+        tokenize_function,
+        batched=True,
+        remove_columns=cols_to_remove,
+        num_proc=4,
     )
     data_collator = DataCollatorWithPadding(tokenizer=tokenizer)
 
@@ -223,7 +246,10 @@ def main() -> None:
     checkpoint_short_name = checkpoint.replace("/", "_")
     effective_batch = batch_size * grad_accum
     fold_str = f"_fold{fold}" if fold is not None else ""
-    run_name = f"{checkpoint_short_name}_seed{seed}_lr{lr}_bs{effective_batch}_freeze{num_freeze}_aug{data_augmentation}{fold_str}"
+    run_name = (
+        f"{checkpoint_short_name}_seed{seed}_lr{lr}_bs{effective_batch}"
+        f"_freeze{num_freeze}_aug{data_augmentation}{fold_str}"
+    )
 
     training_args = TrainingArguments(
         output_dir=f"meaning_bert_train_{checkpoint_short_name}",
@@ -242,6 +268,7 @@ def main() -> None:
         metric_for_best_model="eval_loss",
         learning_rate=lr,
         bf16=use_bf16,
+        fp16=use_fp16,
         dataloader_num_workers=num_workers,
         dataloader_pin_memory=True,
     )
@@ -275,14 +302,16 @@ def main() -> None:
     print("----------Training start----------")
     trainer.train()
 
-    wandb.run.config.update({
-        "data_augmentation": data_augmentation,
-        "fold": fold,
-        "checkpoint": checkpoint,
-        "freeze_layers": num_freeze,
-        "effective_batch_size": effective_batch,
-        "early_stopping_patience": es_patience,
-    })
+    wandb.run.config.update(
+        {
+            "data_augmentation": data_augmentation,
+            "fold": fold,
+            "checkpoint": checkpoint,
+            "freeze_layers": num_freeze,
+            "effective_batch_size": effective_batch,
+            "early_stopping_patience": es_patience,
+        }
+    )
     wandb.log({"Best model checkpoint path": trainer.state.best_model_checkpoint})
 
     # --- Evaluate ---
@@ -297,7 +326,8 @@ def main() -> None:
         tok_identical = holdout_identical_dataset.map(tokenize_function, batched=True, remove_columns=cols)
         trainer.compute_metrics = eval_compute_metrics_identical
         identical_results = trainer.evaluate(
-            eval_dataset=tok_identical["test"], metric_key_prefix="test/identical_sentences",
+            eval_dataset=tok_identical["test"],
+            metric_key_prefix="test/identical_sentences",
         )
 
     if holdout_unrelated_dataset is not None and len(holdout_unrelated_dataset["test"]) > 0:
@@ -305,7 +335,8 @@ def main() -> None:
         tok_unrelated = holdout_unrelated_dataset.map(tokenize_function, batched=True, remove_columns=cols)
         trainer.compute_metrics = eval_compute_metrics_unrelated
         unrelated_results = trainer.evaluate(
-            eval_dataset=tok_unrelated["test"], metric_key_prefix="test/unrelated_sentences",
+            eval_dataset=tok_unrelated["test"],
+            metric_key_prefix="test/unrelated_sentences",
         )
 
     # --- Save & log artifact ---

--- a/src/training/prepare_datasets.py
+++ b/src/training/prepare_datasets.py
@@ -20,6 +20,7 @@ Each fold is stratified on source type (original/identical/unrelated).
 Swap skips identical pairs. Back-translation applied on train split only per fold
 to prevent data leakage (slower but correct).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -87,7 +88,7 @@ def back_translate_batch(
     return results
 
 
-def back_translate_dataset(
+def back_translate_dataset(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     dataset: Dataset,
     en_fr: tuple[MarianTokenizer, MarianMTModel],
     fr_en: tuple[MarianTokenizer, MarianMTModel],
@@ -143,12 +144,14 @@ def back_translate_dataset(
             print(f"  Dropped {n_dropped} bt pairs colliding with dev/test")
         aug_orig, aug_simp, aug_labels = keep_orig, keep_simp, keep_labels
 
-    augmented = Dataset.from_dict({
-        "original": aug_orig,
-        "simplification": aug_simp,
-        "label": aug_labels,
-        "source": ["back_translated"] * len(aug_orig),
-    })
+    augmented = Dataset.from_dict(
+        {
+            "original": aug_orig,
+            "simplification": aug_simp,
+            "label": aug_labels,
+            "source": ["back_translated"] * len(aug_orig),
+        }
+    )
 
     # Ensure original rows are tagged
     if "source" not in dataset.column_names:
@@ -189,12 +192,14 @@ def apply_commutative_swap(dataset: Dataset) -> Dataset:
         swap_simp.append(orig)
         swap_labels.append(label)
 
-    swapped = Dataset.from_dict({
-        "original": swap_orig,
-        "simplification": swap_simp,
-        "label": swap_labels,
-        "source": ["swapped"] * len(swap_orig),
-    })
+    swapped = Dataset.from_dict(
+        {
+            "original": swap_orig,
+            "simplification": swap_simp,
+            "label": swap_labels,
+            "source": ["swapped"] * len(swap_orig),
+        }
+    )
 
     return concatenate_datasets([dataset, swapped])
 
@@ -222,19 +227,27 @@ def create_fold_splits(
     strata = full_dataset[stratify_column]
 
     train_dev_idx, test_idx = train_test_split(
-        indices, test_size=test_ratio, random_state=seed, stratify=strata,
+        indices,
+        test_size=test_ratio,
+        random_state=seed,
+        stratify=strata,
     )
     relative_dev_ratio = dev_ratio / (1 - test_ratio)
     train_dev_strata = [strata[i] for i in train_dev_idx]
     train_idx, dev_idx = train_test_split(
-        train_dev_idx, test_size=relative_dev_ratio, random_state=seed, stratify=train_dev_strata,
+        train_dev_idx,
+        test_size=relative_dev_ratio,
+        random_state=seed,
+        stratify=train_dev_strata,
     )
 
-    return DatasetDict({
-        "train": full_dataset.select(train_idx),
-        "dev": full_dataset.select(dev_idx),
-        "test": full_dataset.select(test_idx),
-    })
+    return DatasetDict(
+        {
+            "train": full_dataset.select(train_idx),
+            "dev": full_dataset.select(dev_idx),
+            "test": full_dataset.select(test_idx),
+        }
+    )
 
 
 def main() -> None:
@@ -281,7 +294,9 @@ def main() -> None:
     full_dataset = full_dataset.select(unique_indices)
 
     print(f"  Full corpus: {len(full_dataset)} examples (after dedup)")
-    print(f"    original: {len(meaning_pool)}, identical: {len(holdout_identical)}, unrelated: {len(holdout_unrelated)}")
+    print(
+        f"    original: {len(meaning_pool)}, identical: {len(holdout_identical)}, unrelated: {len(holdout_unrelated)}"
+    )
 
     # Load translation models once (reused across folds)
     en_fr = None
@@ -311,11 +326,13 @@ def main() -> None:
         base_splits.save_to_disk(base_path)
 
         # 2. Swap (commutative property) - applied only on train
-        swap_splits = DatasetDict({
-            "train": apply_commutative_swap(base_splits["train"]),
-            "dev": base_splits["dev"],
-            "test": base_splits["test"],
-        })
+        swap_splits = DatasetDict(
+            {
+                "train": apply_commutative_swap(base_splits["train"]),
+                "dev": base_splits["dev"],
+                "test": base_splits["test"],
+            }
+        )
         swap_path = os.path.join(fold_dir, "meaning_with_swap")
         swap_splits.save_to_disk(swap_path)
 
@@ -335,27 +352,32 @@ def main() -> None:
 
             print(f"\n  Back-translating fold {fold_idx} train ({len(base_splits['train'])} examples)...")
             bt_train = back_translate_dataset(
-                base_splits["train"], en_fr, fr_en, device, args.batch_size,
+                base_splits["train"],
+                en_fr,
+                fr_en,
+                device,
+                args.batch_size,
                 exclude_fingerprints=dev_test_fps,
             )
             bt_train_swapped = apply_commutative_swap(bt_train)
 
             # Final dedup of swapped bt pairs against dev/test
             keep_indices = [
-                i for i, (o, s) in enumerate(
-                    zip(bt_train_swapped["original"], bt_train_swapped["simplification"])
-                )
+                i
+                for i, (o, s) in enumerate(zip(bt_train_swapped["original"], bt_train_swapped["simplification"]))
                 if f"{o}|||{s}" not in dev_test_fps
             ]
             if len(keep_indices) < len(bt_train_swapped):
                 n_dropped = len(bt_train_swapped) - len(keep_indices)
                 print(f"  Dropped {n_dropped} swapped pairs colliding with dev/test")
                 bt_train_swapped = bt_train_swapped.select(keep_indices)
-            bt_splits = DatasetDict({
-                "train": bt_train_swapped,
-                "dev": base_splits["dev"],
-                "test": base_splits["test"],
-            })
+            bt_splits = DatasetDict(
+                {
+                    "train": bt_train_swapped,
+                    "dev": base_splits["dev"],
+                    "test": base_splits["test"],
+                }
+            )
             bt_path = os.path.join(fold_dir, "meaning_with_back_translation")
             bt_splits.save_to_disk(bt_path)
 
@@ -363,10 +385,12 @@ def main() -> None:
         source_counts: dict[str, int] = {}
         for src in base_splits["train"]["source"]:
             source_counts[src] = source_counts.get(src, 0) + 1
-        print(f"  Fold {fold_idx} (seed={seed}): "
-              f"train={len(base_splits['train'])} {source_counts}, "
-              f"dev={len(base_splits['dev'])}, "
-              f"test={len(base_splits['test'])}")
+        print(
+            f"  Fold {fold_idx} (seed={seed}): "
+            f"train={len(base_splits['train'])} {source_counts}, "
+            f"dev={len(base_splits['dev'])}, "
+            f"test={len(base_splits['test'])}"
+        )
 
     # Free GPU memory
     if en_fr is not None:
@@ -376,7 +400,7 @@ def main() -> None:
 
     print("\n=== Done ===")
     print(f"All datasets saved to {output_dir}/")
-    print(f"Structure:")
+    print("Structure:")
     print(f"  folds/ ({num_folds} folds)")
     for fold_idx in range(num_folds):
         fold_dir = os.path.join(output_dir, "folds", f"fold_{fold_idx}")

--- a/src/training/rerun_failed.py
+++ b/src/training/rerun_failed.py
@@ -1,4 +1,5 @@
 """Relaunch failed wandb runs by parsing their config and re-submitting."""
+
 from __future__ import annotations
 
 import argparse
@@ -26,7 +27,8 @@ def build_command(run: wandb.apis.public.Run) -> list[str]:
     precision_flags = _precision_flags(checkpoint)
 
     return [
-        sys.executable, "few_shot_training.py",
+        sys.executable,
+        "few_shot_training.py",
         f"--checkpoint={checkpoint}",
         f"--fold={fold}",
         f"--seed={seed}",

--- a/src/training/rerun_failed.py
+++ b/src/training/rerun_failed.py
@@ -1,0 +1,100 @@
+"""Relaunch failed wandb runs by parsing their config and re-submitting."""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+import wandb
+
+# phi-2 failed in fp32 due to backward dtype mismatch -> use fp16
+PHI2_CHECKPOINT = "microsoft/phi-2"
+
+COMMON = ["--data_dir=./data", "--early_stopping_patience=50", "--dataloader_num_workers=4"]
+
+
+def build_command(run: wandb.apis.public.Run) -> list[str]:
+    cfg = run.config
+    checkpoint: str = cfg.get("checkpoint") or _parse_checkpoint_from_name(run.name)
+    fold: int = cfg.get("fold") if cfg.get("fold") is not None else _parse_fold_from_name(run.name)
+    aug: str = cfg.get("data_augmentation") or _parse_aug_from_name(run.name)
+    seed: int = cfg.get("seed", 42)
+    lr: float = cfg.get("learning_rate", 1e-5)
+    freeze: int = cfg.get("freeze_layers", 0)
+    bs: int = cfg.get("per_device_train_batch_size", 32)
+
+    precision_flags = _precision_flags(checkpoint)
+
+    return [
+        sys.executable, "few_shot_training.py",
+        f"--checkpoint={checkpoint}",
+        f"--fold={fold}",
+        f"--seed={seed}",
+        f"--data_augmentation={aug}",
+        f"--learning_rate={lr}",
+        f"--freeze_layers={freeze}",
+        f"--per_device_train_batch_size={bs}",
+        *precision_flags,
+        *COMMON,
+    ]
+
+
+def _precision_flags(checkpoint: str) -> list[str]:
+    if checkpoint == PHI2_CHECKPOINT:
+        return ["--no-bf16", "--fp16"]
+    if "gemma" in checkpoint.lower():
+        return ["--no-bf16"]
+    return ["--bf16"]
+
+
+def _parse_checkpoint_from_name(name: str) -> str:
+    # e.g. microsoft_deberta-v3-small_seed42_... -> microsoft/deberta-v3-small
+    base = name.split("_seed")[0]
+    # first underscore that separates org from model name
+    parts = base.split("_", 1)
+    return "/".join(parts) if len(parts) == 2 else base
+
+
+def _parse_fold_from_name(name: str) -> int:
+    for part in name.split("_"):
+        if part.startswith("fold"):
+            return int(part[4:])
+    raise ValueError(f"Cannot parse fold from run name: {name}")
+
+
+def _parse_aug_from_name(name: str) -> str:
+    if "back_translation" in name:
+        return "back_translation"
+    return "swap"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Relaunch failed wandb runs.")
+    parser.add_argument("--project", default="davebulaval/meaningbert-checkpoint-sweep")
+    parser.add_argument("--dry-run", action="store_true", help="Print commands without executing.")
+    parser.add_argument("--filter-checkpoint", default=None, help="Only relaunch runs matching this substring.")
+    args = parser.parse_args()
+
+    api = wandb.Api()
+    failed_runs = list(api.runs(args.project, filters={"state": "failed"}))
+    print(f"Found {len(failed_runs)} failed runs in {args.project}")
+
+    if args.filter_checkpoint:
+        failed_runs = [r for r in failed_runs if args.filter_checkpoint in r.name]
+        print(f"Filtered to {len(failed_runs)} runs matching '{args.filter_checkpoint}'")
+
+    for i, run in enumerate(failed_runs, 1):
+        cmd = build_command(run)
+        label = f"[{i}/{len(failed_runs)}] {run.name}"
+        print(f"\n=== {label} ===")
+        print("  " + " ".join(cmd))
+        if not args.dry_run:
+            result = subprocess.run(cmd)
+            if result.returncode != 0:
+                print(f"  ERROR: run failed with exit code {result.returncode}")
+
+    print(f"\nDone: {len(failed_runs)} runs {'(dry-run)' if args.dry_run else 'completed'}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/training/rerun_failed.sh
+++ b/src/training/rerun_failed.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Rerun 100 failed runs:
+#   - 80 deberta (v2-xlarge, v3-small/base/large): nvrtc fix applied 2026-04-14
+#   - 20 phi-2: now uses fp16 instead of fp32 (backward dtype mismatch fix)
+# Run on caribou after libnvrtc-builtins.so.13.0 is confirmed installed.
+export WANDB_PROJECT="meaningbert-checkpoint-sweep"
+
+FOLDS=(0 1 2 3 4 5 6 7 8 9)
+SEEDS=(42 43 44 45 46 47 48 49 50 51)
+AUGMENTATIONS=("swap" "back_translation")
+
+TOTAL=100
+RUN=0
+
+# --- GPU 2: deberta-v2-xlarge (bf16, same as original) ---
+export CUDA_VISIBLE_DEVICES=2
+COMMON_BF16="--data_dir=./data --early_stopping_patience=50 --bf16 --dataloader_num_workers=4"
+
+for aug in "${AUGMENTATIONS[@]}"; do
+    for i in "${!FOLDS[@]}"; do
+        fold=${FOLDS[$i]}; seed=${SEEDS[$i]}; RUN=$((RUN + 1))
+        echo "=== [GPU 2] [${RUN}/${TOTAL}] deberta-v2-xlarge fold=${fold} aug=${aug} ==="
+        python few_shot_training.py --seed="${seed}" --fold="${fold}" \
+            --checkpoint="microsoft/deberta-v2-xlarge" --learning_rate="1e-5" \
+            --freeze_layers=12 --per_device_train_batch_size=32 \
+            --data_augmentation="${aug}" ${COMMON_BF16}
+    done
+done
+
+# phi-2: fp16 (bf16 -> NaN, fp32 -> backward dtype mismatch)
+COMMON_FP16="--data_dir=./data --early_stopping_patience=50 --no-bf16 --fp16 --dataloader_num_workers=4"
+
+for aug in "${AUGMENTATIONS[@]}"; do
+    for i in "${!FOLDS[@]}"; do
+        fold=${FOLDS[$i]}; seed=${SEEDS[$i]}; RUN=$((RUN + 1))
+        echo "=== [GPU 2] [${RUN}/${TOTAL}] phi-2 fold=${fold} aug=${aug} (fp16) ==="
+        python few_shot_training.py --seed="${seed}" --fold="${fold}" \
+            --checkpoint="microsoft/phi-2" --learning_rate="1e-5" \
+            --freeze_layers=10 --per_device_train_batch_size=4 \
+            --data_augmentation="${aug}" ${COMMON_FP16}
+    done
+done
+
+# --- GPU 1: deberta-v3-base + deberta-v3-large ---
+export CUDA_VISIBLE_DEVICES=1
+
+for aug in "${AUGMENTATIONS[@]}"; do
+    for i in "${!FOLDS[@]}"; do
+        fold=${FOLDS[$i]}; seed=${SEEDS[$i]}; RUN=$((RUN + 1))
+        echo "=== [GPU 1] [${RUN}/${TOTAL}] deberta-v3-base fold=${fold} aug=${aug} ==="
+        python few_shot_training.py --seed="${seed}" --fold="${fold}" \
+            --checkpoint="microsoft/deberta-v3-base" --learning_rate="2e-5" \
+            --freeze_layers=0 --per_device_train_batch_size=128 \
+            --data_augmentation="${aug}" ${COMMON_BF16}
+    done
+done
+
+for aug in "${AUGMENTATIONS[@]}"; do
+    for i in "${!FOLDS[@]}"; do
+        fold=${FOLDS[$i]}; seed=${SEEDS[$i]}; RUN=$((RUN + 1))
+        echo "=== [GPU 1] [${RUN}/${TOTAL}] deberta-v3-large fold=${fold} aug=${aug} ==="
+        python few_shot_training.py --seed="${seed}" --fold="${fold}" \
+            --checkpoint="microsoft/deberta-v3-large" --learning_rate="2e-5" \
+            --freeze_layers=6 --per_device_train_batch_size=64 \
+            --data_augmentation="${aug}" ${COMMON_BF16}
+    done
+done
+
+# --- GPU 0: deberta-v3-small ---
+export CUDA_VISIBLE_DEVICES=0
+
+for aug in "${AUGMENTATIONS[@]}"; do
+    for i in "${!FOLDS[@]}"; do
+        fold=${FOLDS[$i]}; seed=${SEEDS[$i]}; RUN=$((RUN + 1))
+        echo "=== [GPU 0] [${RUN}/${TOTAL}] deberta-v3-small fold=${fold} aug=${aug} ==="
+        python few_shot_training.py --seed="${seed}" --fold="${fold}" \
+            --checkpoint="microsoft/deberta-v3-small" --learning_rate="2e-5" \
+            --freeze_layers=0 --per_device_train_batch_size=128 \
+            --data_augmentation="${aug}" ${COMMON_BF16}
+    done
+done
+
+echo "=== Rerun done: ${TOTAL}/${TOTAL} ==="

--- a/src/training/sweep_gpu2.sh
+++ b/src/training/sweep_gpu2.sh
@@ -21,11 +21,17 @@ MODELS_BF16=(
 declare -A MODELS_FP32
 MODELS_FP32=(
     ["google/gemma-2-2b"]="1e-5 10 4"
+)
+
+# phi-2: bf16 causes NaN, fp32 causes dtype mismatch in backward -> use fp16
+declare -A MODELS_FP16
+MODELS_FP16=(
     ["microsoft/phi-2"]="1e-5 10 4"
 )
 
 COMMON_BF16="--data_dir=./data --early_stopping_patience=50 --bf16 --dataloader_num_workers=4"
 COMMON_FP32="--data_dir=./data --early_stopping_patience=50 --no-bf16 --dataloader_num_workers=4"
+COMMON_FP16="--data_dir=./data --early_stopping_patience=50 --no-bf16 --fp16 --dataloader_num_workers=4"
 
 for checkpoint in "${!MODELS_BF16[@]}"; do
     read -r lr freeze bs <<< "${MODELS_BF16[$checkpoint]}"
@@ -55,6 +61,22 @@ for checkpoint in "${!MODELS_FP32[@]}"; do
                 --checkpoint="${checkpoint}" --learning_rate="${lr}" \
                 --freeze_layers="${freeze}" --per_device_train_batch_size="${bs}" \
                 --data_augmentation="${aug}" ${COMMON_FP32}
+        done
+    done
+done
+
+for checkpoint in "${!MODELS_FP16[@]}"; do
+    read -r lr freeze bs <<< "${MODELS_FP16[$checkpoint]}"
+    for aug in "${AUGMENTATIONS[@]}"; do
+        for i in "${!FOLDS[@]}"; do
+            fold=${FOLDS[$i]}
+            seed=${SEEDS[$i]}
+            RUN=$((RUN + 1))
+            echo "=== [GPU 2] [${RUN}/${TOTAL}] ${checkpoint} fold=${fold} aug=${aug} (fp16) ==="
+            python few_shot_training.py --seed="${seed}" --fold="${fold}" \
+                --checkpoint="${checkpoint}" --learning_rate="${lr}" \
+                --freeze_layers="${freeze}" --per_device_train_batch_size="${bs}" \
+                --data_augmentation="${aug}" ${COMMON_FP16}
         done
     done
 done

--- a/src/training/validate_datasets.py
+++ b/src/training/validate_datasets.py
@@ -13,6 +13,7 @@ Checks:
     - Back-translation: corpus is larger than swap variant
     - Column consistency across all datasets
 """
+
 from __future__ import annotations
 
 import argparse
@@ -85,7 +86,10 @@ def check_swap_present(swap_dataset, base_dataset, split_name: str, fold_name: s
     if split_name != "train":
         return True
     if len(swap_dataset) <= len(base_dataset):
-        print(f"  FAIL [{fold_name}/{split_name}]: swap ({len(swap_dataset)}) should be larger than base ({len(base_dataset)})")
+        print(
+            f"  FAIL [{fold_name}/{split_name}]: swap ({len(swap_dataset)})"
+            f" should be larger than base ({len(base_dataset)})"
+        )
         return False
     return True
 
@@ -193,7 +197,10 @@ def main() -> None:
                 bt_train = len(datasets["meaning_with_back_translation"]["train"])
                 swap_train = len(datasets["meaning_with_swap"]["train"])
                 if bt_train <= swap_train:
-                    print(f"  FAIL [{fold_name}]: back_translation train ({bt_train}) should be larger than swap train ({swap_train})")
+                    print(
+                        f"  FAIL [{fold_name}]: back_translation train ({bt_train})"
+                        f" should be larger than swap train ({swap_train})"
+                    )
                     errors += 1
 
         # Print stats for this fold


### PR DESCRIPTION
## Summary

- Add `--fp16` flag to `few_shot_training.py` for phi-2 (bf16 → NaN, fp32 → backward dtype mismatch, fp16 works)
- Split phi-2 into `MODELS_FP16` group in `sweep_gpu2.sh`
- Add `rerun_failed.py`: queries wandb API for failed runs and relaunches with correct precision flags
- Add `rerun_failed.sh`: hardcoded relance script for 100 failed runs (80 deberta nvrtc fix + 20 phi-2 fp16)
- Fix pylint warnings across files reformatted by black

## Context

260/280 runs completed. 100 failed:
- 80 runs (deberta-v2-xlarge + v3-small/base/large): nvrtc `libnvrtc-builtins.so.13.0` error, fixed by installing the library on caribou
- 20 runs (phi-2): `RuntimeError: Found dtype Float but expected Half` in backward pass — fixed with fp16

## Test plan

- [ ] `python rerun_failed.py --dry-run` confirms correct flags per checkpoint
- [ ] phi-2 fold0 swap runs to completion without dtype error
- [ ] deberta-v3 fold0 swap runs to completion without nvrtc error

Generated with [Claude Code](https://claude.com/claude-code)